### PR TITLE
feat: add reusable modal system with theme support and view registry

### DIFF
--- a/.claude/rules/widgets.md
+++ b/.claude/rules/widgets.md
@@ -17,5 +17,9 @@ path: "lib/src/ui/widgets/**/*.dart"
 - Page header: `WDiv` with `flex-col sm:flex-row` responsive layout, `border-b` separator, required `title`, optional `subtitle` (`String?`), optional `leading` widget (e.g. back button), optional `actions` (`List<Widget>?`) — rendered in a trailing `flex flex-row gap-2` row only when non-empty
 - User profile dropdown: `PopupMenuButton` with avatar, name, role — navigates to profile/logout
 - User profile dropdown avatar: uses `MagicStarter.navigationTheme.dropdownAvatarClassName` for the trigger avatar background — override via `MagicStarter.useNavigationTheme()`
-- Wind UI exclusively — no Material widgets except `Icons.*` for icon references
+- Confirm dialog: `MagicStarterConfirmDialog` with `static Future<bool> show(BuildContext context, {required String title, String? description, String? confirmLabel, String? cancelLabel, ConfirmDialogVariant variant, Future<void> Function()? onConfirm})`; variant enum `ConfirmDialogVariant.primary` (default), `.danger`, `.warning` — controls confirm button styling
+- Confirm dialog variant usage: `ConfirmDialogVariant.danger` for destructive actions (delete team, revoke session), `.warning` for caution (leave team), `.primary` for neutral confirmations
+- Modal theme consumption: all dialogs (ConfirmDialog, PasswordConfirmDialog, TwoFactorModal) read tokens from `MagicStarter.manager.modalTheme` at build time — never hardcode dialog classNames; use theme fields (titleClassName, primaryButtonClassName, dangerButtonClassName, etc.)
+- Dialog shell: `MagicStarterDialogShell` is internal-only (NOT exported from barrel) — sticky header/footer with scrollable body; uses Material Dialog shell + Wind UI content; all exported dialogs compose on top of it
+- Wind UI exclusively — no Material widgets except `Icons.*` for icon references and `Dialog` shell in `MagicStarterDialogShell`
 - Dark mode: always pair light/dark classes: `bg-white dark:bg-gray-800`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### ✨ New Features
+- **MagicStarterModalTheme**: Added configurable modal theme system via `MagicStarter.useModalTheme()` with 13 Wind UI className token fields (containerClassName, headerClassName, bodyClassName, footerClassName, titleClassName, descriptionClassName, primaryButtonClassName, secondaryButtonClassName, dangerButtonClassName, warningButtonClassName, errorClassName, inputClassName, maxWidth). All fields optional — zero breaking changes.
+- **MagicStarterConfirmDialog**: Generic confirmation dialog with `ConfirmDialogVariant` enum (`primary`, `danger`, `warning`). Static `show()` factory supports async `onConfirm` callback, custom labels, and description. Exported from barrel.
+- **Modal View Registry**: Extended `MagicStarterViewRegistry` with `registerModal(key, builder)`, `hasModal(key)`, and `makeModal(key)`. Three default modals auto-registered: `modal.confirm`, `modal.password_confirm`, `modal.two_factor`.
+- **MagicStarterDialogShell**: Internal composition widget with sticky header/footer and scrollable body. Uses Material Dialog shell + Wind UI content. Not exported — internal use only.
+
+### 🔧 Improvements
+- **PasswordConfirmDialog**: Now reads theme tokens from `MagicStarter.manager.modalTheme` instead of hardcoded classNames
+- **TwoFactorModal**: Now reads theme tokens from `MagicStarter.manager.modalTheme` instead of hardcoded classNames
+- **Team Settings**: Replaced Material `AlertDialog` with `MagicStarterConfirmDialog.show()` using `ConfirmDialogVariant.danger`
+
 ## [0.0.1-alpha.3] - 2026-03-26
 
 ### ✨ New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.0.1-alpha.4] - 2026-03-29
+
 ### ✨ New Features
 - **MagicStarterModalTheme**: Added configurable modal theme system via `MagicStarter.useModalTheme()` with 13 Wind UI className token fields (containerClassName, headerClassName, bodyClassName, footerClassName, titleClassName, descriptionClassName, primaryButtonClassName, secondaryButtonClassName, dangerButtonClassName, warningButtonClassName, errorClassName, inputClassName, maxWidth). All fields optional — zero breaking changes.
 - **MagicStarterConfirmDialog**: Generic confirmation dialog with `ConfirmDialogVariant` enum (`primary`, `danger`, `warning`). Static `show()` factory supports async `onConfirm` callback, custom labels, and description. Exported from barrel.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Flutter starter kit for the Magic Framework. Pre-built Auth, Profile, Teams & Notifications — 13 opt-in features, every screen overridable via Wind UI.
 
-**Version:** 0.0.1-alpha.3 · **Dart:** >=3.6.0 · **Flutter:** >=3.27.0
+**Version:** 0.0.1-alpha.4 · **Dart:** >=3.6.0 · **Flutter:** >=3.27.0
 
 ## Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,11 +103,13 @@ Every feature, fix, or refactor must go through the red-green-refactor cycle:
 | `CardVariant` import | `CardVariant` is exported from the main barrel; import `package:magic_starter/magic_starter.dart` — no direct widget file import needed |
 | Navigation theme not affecting UI | `MagicStarter.useNavigationTheme()` must be called before the app layout is first painted — ideally in `AppServiceProvider.boot()` |
 | `brandBuilder` + `brandClassName` both set | `brandBuilder` wins — `brandClassName` is ignored when a builder is registered |
+| Modal theme not affecting dialogs | `MagicStarter.useModalTheme()` must be called before any dialog is shown — ideally in `AppServiceProvider.boot()` |
+| Hardcoding dialog classNames | All modal classNames must come from `MagicStarter.manager.modalTheme` — never hardcode in widget build methods |
 
 ## Skills & Extensions
 
 - `fluttersdk:magic-framework` — Magic Framework patterns: facades, service providers, IoC, Eloquent ORM, controllers, routing. Use for ANY code touching Magic APIs.
-- `fluttersdk:magic-starter-widgets` — Reusable standalone widgets exported from `package:magic_starter/magic_starter.dart`: `MagicStarterCard` (with `CardVariant` enum: surface/inset/elevated), `MagicStarterPageHeader` (title, subtitle, leading, actions), `MagicStarterPasswordConfirmDialog`, `MagicStarterTwoFactorModal`. All accept plain callbacks — no internal controller coupling required.
+- `fluttersdk:magic-starter-widgets` — Reusable standalone widgets exported from `package:magic_starter/magic_starter.dart`: `MagicStarterCard` (with `CardVariant` enum: surface/inset/elevated), `MagicStarterPageHeader` (title, subtitle, leading, actions), `MagicStarterConfirmDialog` (with `ConfirmDialogVariant` enum: primary/danger/warning), `MagicStarterPasswordConfirmDialog`, `MagicStarterTwoFactorModal`. All accept plain callbacks — no internal controller coupling required. All modals read `MagicStarterModalTheme` tokens at build time.
 
 ## CI
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Stop rebuilding authentication, profile management, and team features from scrat
 | :bell: | **Notifications** | Real-time polling, mark read/unread, preference matrix |
 | :iphone: | **OTP Login** | Phone-based guest authentication with send/verify flow |
 | :art: | **Wind UI** | Tailwind-like className system — no Material widgets, dark mode built-in |
-| :package: | **Reusable Widgets** | PageHeader, Card (3 variants), PasswordConfirmDialog, TwoFactorModal — all standalone |
+| :package: | **Reusable Widgets** | PageHeader, Card (3 variants), ConfirmDialog (3 variants), PasswordConfirmDialog, TwoFactorModal — all standalone |
 | :gear: | **13 Feature Toggles** | All opt-in, configure only what you need |
 | :jigsaw: | **View Registry** | Override any screen or layout from the host app |
 | :hammer_and_wrench: | **CLI Tools** | install, configure, doctor, publish, uninstall |
@@ -273,7 +273,9 @@ All widgets are exported from `package:magic_starter/magic_starter.dart`.
 
 ---
 
-## Navigation Theme
+## Theming
+
+### Navigation Theme
 
 Customize navigation colors, the brand/logo, and avatar styles without overriding any screens:
 
@@ -304,7 +306,23 @@ MagicStarter.useNavigationTheme(
 );
 ```
 
-All fields are optional — defaults preserve the current `text-primary` / `bg-primary/10` behavior.
+### Modal Theme
+
+Customize dialog and modal styles — confirmation dialogs, password prompts, and two-factor modals all read from this theme:
+
+```dart
+MagicStarter.useModalTheme(
+  MagicStarterModalTheme(
+    containerClassName: 'rounded-2xl bg-white dark:bg-gray-900',
+    titleClassName: 'text-lg font-semibold text-gray-900 dark:text-white',
+    primaryButtonClassName: 'bg-primary hover:bg-primary/90 text-white',
+    dangerButtonClassName: 'bg-red-600 hover:bg-red-700 text-white',
+    maxWidth: 480,
+  ),
+);
+```
+
+All theme fields are optional — omitted fields fall back to sensible defaults. Call both `useNavigationTheme()` and `useModalTheme()` in `AppServiceProvider.boot()` before any UI is painted.
 
 ---
 

--- a/doc/architecture/manager.md
+++ b/doc/architecture/manager.md
@@ -209,7 +209,7 @@ All fields are optional — omitted fields fall back to the current defaults.
 | `warningButtonClassName` | Default warning | Warning action button |
 | `errorClassName` | Default error | Inline error message text style |
 | `inputClassName` | Default input | Text input fields inside dialogs |
-| `maxWidth` | `null` | Maximum dialog width in logical pixels |
+| `maxWidth` | `448.0` | Maximum dialog width in logical pixels |
 
 The theme is stored on `MagicStarterManager` as `modalTheme` and reset to defaults by `manager.reset()`. The active theme is read at widget build time, so `useModalTheme()` can be called at any point before a dialog is shown.
 

--- a/doc/architecture/manager.md
+++ b/doc/architecture/manager.md
@@ -6,6 +6,7 @@
 - [Team Resolver](#team-resolver)
 - [Navigation Configuration](#navigation-configuration)
 - [Navigation Theme](#navigation-theme)
+- [Modal Theme](#modal-theme)
 - [Header Builder](#header-builder)
 - [Logout Callback](#logout-callback)
 - [Notification Type Mapper](#notification-type-mapper)
@@ -172,6 +173,49 @@ The theme is stored on `MagicStarterManager` as `navigationTheme` and reset to d
 > [!NOTE]
 > When `brandBuilder` is set, `brandClassName` is ignored. The builder receives the current `BuildContext` and should return any widget — `Image.asset`, `SvgPicture.asset`, a styled `WText`, etc.
 
+<a name="modal-theme"></a>
+## Modal Theme
+
+`MagicStarterModalTheme` overrides the default Wind UI tokens used for all modal dialogs — confirmation dialogs, password prompts, and two-factor modals. Works the same way as `NavigationTheme`: register once, all modals pick up the tokens at build time.
+
+```dart
+MagicStarter.useModalTheme(
+  MagicStarterModalTheme(
+    containerClassName: 'rounded-2xl bg-white dark:bg-gray-900',
+    titleClassName: 'text-lg font-semibold text-gray-900 dark:text-white',
+    descriptionClassName: 'text-sm text-gray-500 dark:text-gray-400',
+    primaryButtonClassName: 'bg-primary hover:bg-primary/90 text-white',
+    dangerButtonClassName: 'bg-red-600 hover:bg-red-700 text-white',
+    warningButtonClassName: 'bg-amber-500 hover:bg-amber-600 text-white',
+    inputClassName: 'rounded-lg border border-gray-300 dark:border-gray-600',
+    maxWidth: 480,
+  ),
+);
+```
+
+All fields are optional — omitted fields fall back to the current defaults.
+
+| Field | Default | Controls |
+|-------|---------|---------|
+| `containerClassName` | Default dialog container | Outer dialog container background, border-radius, border |
+| `headerClassName` | Default header | Dialog header section (sticky top) |
+| `bodyClassName` | Default body | Scrollable body section |
+| `footerClassName` | Default footer | Dialog footer section (sticky bottom) |
+| `titleClassName` | Default title | Dialog title text style |
+| `descriptionClassName` | Default description | Dialog description/subtitle text style |
+| `primaryButtonClassName` | Default primary | Primary action button (confirm, save) |
+| `secondaryButtonClassName` | Default secondary | Secondary action button (cancel, dismiss) |
+| `dangerButtonClassName` | Default danger | Danger action button (delete, destroy) |
+| `warningButtonClassName` | Default warning | Warning action button |
+| `errorClassName` | Default error | Inline error message text style |
+| `inputClassName` | Default input | Text input fields inside dialogs |
+| `maxWidth` | `null` | Maximum dialog width in logical pixels |
+
+The theme is stored on `MagicStarterManager` as `modalTheme` and reset to defaults by `manager.reset()`. The active theme is read at widget build time, so `useModalTheme()` can be called at any point before a dialog is shown.
+
+> [!TIP]
+> Register your modal theme in `AppServiceProvider.boot()` alongside `useNavigationTheme()`. Both follow the same pattern — register once, all widgets read the tokens at build time.
+
 <a name="header-builder"></a>
 ## Header Builder
 
@@ -292,6 +336,7 @@ Default layouts:
 | `MagicStarter.useTeamResolver(...)` | `manager.teamResolver = config` |
 | `MagicStarter.useNavigation(...)` | `manager.navigationConfig = config` |
 | `MagicStarter.useNavigationTheme(theme)` | `manager.navigationTheme = theme` |
+| `MagicStarter.useModalTheme(theme)` | `manager.modalTheme = theme` |
 | `MagicStarter.useHeader(builder)` | `manager.headerBuilder = builder` |
 | `MagicStarter.useLogout(callback)` | `manager.onLogout = callback` |
 | `MagicStarter.useSocialLogin(builder)` | `manager.socialLoginBuilder = builder` |

--- a/doc/architecture/view-registry.md
+++ b/doc/architecture/view-registry.md
@@ -33,7 +33,7 @@ The registry maintains three internal maps — one for view builders, one for la
 ```dart
 final Map<String, MagicStarterViewBuilder> _builders = {};
 final Map<String, MagicStarterLayoutBuilder> _layouts = {};
-final Map<String, MagicStarterViewBuilder> _modals = {};
+final Map<String, MagicStarterModalBuilder> _modals = {};
 ```
 
 The builder typedefs:
@@ -41,6 +41,7 @@ The builder typedefs:
 ```dart
 typedef MagicStarterViewBuilder = Widget Function();
 typedef MagicStarterLayoutBuilder = Widget Function(Widget child);
+typedef MagicStarterModalBuilder = Widget Function();
 ```
 
 <a name="registering-views"></a>
@@ -65,7 +66,7 @@ Stores a layout builder under the given key. Layout builders receive a `Widget c
 ### Registering Modals
 
 ```dart
-void registerModal(String key, MagicStarterViewBuilder builder)
+void registerModal(String key, MagicStarterModalBuilder builder)
 ```
 
 Stores a modal builder under the given key. Modal builders return a widget that is displayed inside a dialog shell. If the key already exists, the previous builder is replaced.
@@ -90,7 +91,7 @@ Widget makeLayout(String key, {required Widget child})
 Widget makeModal(String key)
 ```
 
-Both methods throw `StateError` when the requested key is not registered:
+All three methods throw `StateError` when the requested key is not registered:
 
 ```dart
 throw StateError('No view builder registered for key "$key".');

--- a/doc/architecture/view-registry.md
+++ b/doc/architecture/view-registry.md
@@ -4,13 +4,16 @@
 - [MagicStarterViewRegistry Class](#magicstarterviewregistry-class)
     - [Registering Views](#registering-views)
     - [Registering Layouts](#registering-layouts)
+    - [Registering Modals](#registering-modals)
     - [Checking Existence](#checking-existence)
     - [Building Widgets](#building-widgets)
     - [Clearing the Registry](#clearing-the-registry)
 - [Default View Keys](#default-view-keys)
 - [Default Layout Keys](#default-layout-keys)
+- [Default Modal Keys](#default-modal-keys)
 - [Overriding Views](#overriding-views)
 - [Overriding Layouts](#overriding-layouts)
+- [Overriding Modals](#overriding-modals)
 - [Route Integration](#route-integration)
 - [Testing](#testing)
 - [Related](#related)
@@ -25,11 +28,12 @@ The registry lives at `lib/src/ui/magic_starter_view_registry.dart` and is held 
 <a name="magicstarterviewregistry-class"></a>
 ## MagicStarterViewRegistry Class
 
-The registry maintains two internal maps — one for view builders and one for layout builders:
+The registry maintains three internal maps — one for view builders, one for layout builders, and one for modal builders:
 
 ```dart
 final Map<String, MagicStarterViewBuilder> _builders = {};
 final Map<String, MagicStarterLayoutBuilder> _layouts = {};
+final Map<String, MagicStarterViewBuilder> _modals = {};
 ```
 
 The builder typedefs:
@@ -57,12 +61,22 @@ void registerLayout(String key, MagicStarterLayoutBuilder builder)
 
 Stores a layout builder under the given key. Layout builders receive a `Widget child` and wrap it in a layout shell (sidebar, header, footer, etc.).
 
+<a name="registering-modals"></a>
+### Registering Modals
+
+```dart
+void registerModal(String key, MagicStarterViewBuilder builder)
+```
+
+Stores a modal builder under the given key. Modal builders return a widget that is displayed inside a dialog shell. If the key already exists, the previous builder is replaced.
+
 <a name="checking-existence"></a>
 ### Checking Existence
 
 ```dart
 bool has(String key)       // true when a view builder exists for key
 bool hasLayout(String key) // true when a layout builder exists for key
+bool hasModal(String key)  // true when a modal builder exists for key
 ```
 
 Used internally by `registerDefaultViews()` to implement the "register if absent" pattern.
@@ -73,6 +87,7 @@ Used internally by `registerDefaultViews()` to implement the "register if absent
 ```dart
 Widget make(String key)
 Widget makeLayout(String key, {required Widget child})
+Widget makeModal(String key)
 ```
 
 Both methods throw `StateError` when the requested key is not registered:
@@ -91,7 +106,7 @@ throw StateError('No view builder registered for key "$key".');
 void clear()
 ```
 
-Removes all view and layout builders. Used in test teardowns and by `MagicStarterManager.reset()`.
+Removes all view, layout, and modal builders. Used in test teardowns and by `MagicStarterManager.reset()`.
 
 <a name="default-view-keys"></a>
 ## Default View Keys
@@ -143,6 +158,15 @@ These are registered by `MagicStarterManager.registerDefaultViews()` at construc
 | `layout.app` | `MagicStarterAppLayout` | Authenticated pages — sidebar, header, bottom nav |
 | `layout.guest` | `MagicStarterGuestLayout` | Auth pages — centered card, minimal chrome |
 
+<a name="default-modal-keys"></a>
+## Default Modal Keys
+
+| Key | Modal | Purpose |
+|-----|-------|---------|
+| `modal.confirm` | `MagicStarterConfirmDialog` | Generic confirmation with `ConfirmDialogVariant` (primary/danger/warning) |
+| `modal.password_confirm` | `MagicStarterPasswordConfirmDialog` | Password-confirmation prompt with inline error handling |
+| `modal.two_factor` | `MagicStarterTwoFactorModal` | Multi-step 2FA wizard (QR code, OTP confirm, recovery codes) |
+
 <a name="overriding-views"></a>
 ## Overriding Views
 
@@ -184,6 +208,23 @@ MagicStarter.view.registerLayout(
 
 > [!NOTE]
 > When overriding `layout.app`, your custom layout is responsible for rendering navigation, header, and responsive behavior. The plugin's controllers still work — only the layout shell changes.
+
+<a name="overriding-modals"></a>
+## Overriding Modals
+
+Replace the default modal for any registered key:
+
+```dart
+MagicStarter.view.registerModal(
+  'modal.confirm',
+  () => const MyCustomConfirmDialog(),
+);
+```
+
+Modal builders follow the same "register if absent" pattern as views and layouts. Overrides registered before the manager is instantiated take precedence automatically.
+
+> [!TIP]
+> Override modals when you need a completely custom dialog design. For style-only changes (colors, fonts, borders), use `MagicStarter.useModalTheme()` instead — it requires no view overrides.
 
 <a name="route-integration"></a>
 ## Route Integration

--- a/doc/basics/views-and-layouts.md
+++ b/doc/basics/views-and-layouts.md
@@ -534,6 +534,44 @@ MagicStarterCard(
 
 When `noPadding` is `true` and a `title` is provided, the title automatically receives `px-6 pt-6 pb-3` spacing so it aligns with full-bleed row content that uses `px-6`.
 
+### MagicStarterConfirmDialog
+
+Generic confirmation dialog with variant-driven styling. Uses `MagicStarterDialogShell` internally for sticky header/footer layout. All classNames are read from `MagicStarter.manager.modalTheme` at build time.
+
+```dart
+final confirmed = await MagicStarterConfirmDialog.show(
+  context,
+  title: trans('teams.remove_member_label'),
+  description: trans('teams.confirm_remove_member'),
+  confirmLabel: trans('teams.remove'),
+  variant: ConfirmDialogVariant.danger,
+  onConfirm: () async {
+    await TeamService.removeMember(memberId);
+  },
+);
+
+if (confirmed) _refreshMembers();
+```
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `title` | `String` | **required** | Dialog title text |
+| `description` | `String?` | `null` | Optional description below the title |
+| `confirmLabel` | `String?` | `trans('common.confirm')` | Confirm button label |
+| `cancelLabel` | `String?` | `trans('common.cancel')` | Cancel button label |
+| `variant` | `ConfirmDialogVariant` | `.primary` | Button styling variant |
+| `onConfirm` | `Future<void> Function()?` | `null` | Async action on confirm — dialog shows loading state |
+
+**Variants:**
+
+| Variant | Use case | Confirm button style |
+|---------|----------|---------------------|
+| `ConfirmDialogVariant.primary` | Neutral confirmations | `theme.primaryButtonClassName` |
+| `ConfirmDialogVariant.danger` | Destructive actions (delete, remove, revoke) | `theme.dangerButtonClassName` |
+| `ConfirmDialogVariant.warning` | Caution actions (leave, archive) | `theme.warningButtonClassName` |
+
+Returns `true` when confirmed, `false` when cancelled or dismissed.
+
 ### MagicStarterPasswordConfirmDialog
 
 Standalone password-confirmation dialog. Pass an `onConfirm` callback that returns `null` on success or an error string to display inline. The dialog stays open on error; it closes automatically on success and returns `true`.

--- a/lib/magic_starter.dart
+++ b/lib/magic_starter.dart
@@ -40,6 +40,7 @@ export 'src/ui/widgets/magic_starter_user_profile_dropdown.dart';
 export 'src/ui/widgets/magic_starter_social_divider.dart';
 export 'src/ui/widgets/magic_starter_notification_dropdown.dart';
 export 'src/ui/widgets/magic_starter_password_confirm_dialog.dart';
+export 'src/ui/widgets/magic_starter_confirm_dialog.dart';
 export 'src/ui/widgets/magic_starter_two_factor_modal.dart';
 export 'src/ui/widgets/magic_starter_timezone_select.dart';
 export 'src/ui/widgets/magic_starter_page_header.dart';

--- a/lib/src/facades/magic_starter.dart
+++ b/lib/src/facades/magic_starter.dart
@@ -266,6 +266,34 @@ class MagicStarter {
   static MagicStarterNavigationTheme get navigationTheme =>
       manager.navigationTheme;
 
+  /// Register a custom modal theme.
+  ///
+  /// When set, overrides the default Wind UI class names used for modal
+  /// containers, headers, bodies, footers, buttons, inputs, and typography.
+  ///
+  /// All fields in [MagicStarterModalTheme] are optional — pass only the
+  /// values you want to customise.
+  ///
+  /// ```dart
+  /// MagicStarter.useModalTheme(
+  ///   MagicStarterModalTheme(
+  ///     containerClassName: 'bg-zinc-900 rounded-2xl border border-zinc-700',
+  ///     primaryButtonClassName:
+  ///         'px-6 py-3 rounded-xl bg-indigo-600 hover:bg-indigo-700 text-white font-semibold',
+  ///     maxWidth: 560.0,
+  ///   ),
+  /// );
+  /// ```
+  static void useModalTheme(MagicStarterModalTheme theme) {
+    manager.modalTheme = theme;
+  }
+
+  /// Get the active modal theme.
+  ///
+  /// Returns the theme registered via [useModalTheme], or a default
+  /// [MagicStarterModalTheme] instance when not configured.
+  static MagicStarterModalTheme get modalTheme => manager.modalTheme;
+
   /// Check if the starter is ready.
   static bool get isReady => manager.isReady;
 }

--- a/lib/src/magic_starter_manager.dart
+++ b/lib/src/magic_starter_manager.dart
@@ -8,6 +8,9 @@ import 'models/magic_starter_nav_item.dart';
 import 'models/magic_starter_team.dart';
 import 'ui/layouts/magic_starter_app_layout.dart';
 import 'ui/layouts/magic_starter_guest_layout.dart';
+import 'ui/widgets/magic_starter_confirm_dialog.dart';
+import 'ui/widgets/magic_starter_password_confirm_dialog.dart';
+import 'ui/widgets/magic_starter_two_factor_modal.dart';
 import 'ui/magic_starter_view_registry.dart';
 import 'ui/views/auth/magic_starter_forgot_password_view.dart';
 import 'ui/views/auth/magic_starter_login_view.dart';
@@ -139,6 +142,119 @@ class MagicStarterNavigationTheme {
   });
 }
 
+/// Theme configuration for modal/dialog colors and styling.
+///
+/// Allows consumer apps to override the default Wind UI class names used for
+/// modal containers, headers, bodies, footers, buttons, inputs, and typography.
+///
+/// All fields are optional — defaults preserve a sensible dark-mode-aware style
+/// with no breaking changes.
+///
+/// ### Example
+/// ```dart
+/// MagicStarter.useModalTheme(
+///   MagicStarterModalTheme(
+///     containerClassName: 'bg-zinc-900 rounded-2xl border border-zinc-700',
+///     primaryButtonClassName:
+///         'px-6 py-3 rounded-xl bg-indigo-600 hover:bg-indigo-700 text-white font-semibold',
+///     maxWidth: 560.0,
+///   ),
+/// );
+/// ```
+class MagicStarterModalTheme {
+  /// Container/dialog background and border-radius className.
+  ///
+  /// Defaults to `'bg-white dark:bg-gray-800 rounded-2xl'`.
+  final String containerClassName;
+
+  /// Header section className (wraps title + description).
+  ///
+  /// Defaults to `'px-6 pt-6 pb-4'`.
+  final String headerClassName;
+
+  /// Body section className (main content area).
+  ///
+  /// Defaults to `'px-6 pb-4'`.
+  final String bodyClassName;
+
+  /// Footer section className (action buttons row).
+  ///
+  /// Defaults to `'px-6 py-4 bg-gray-50 dark:bg-gray-800/50'`.
+  final String footerClassName;
+
+  /// Title text className.
+  ///
+  /// Defaults to `'text-xl font-semibold text-gray-900 dark:text-white mb-2'`.
+  final String titleClassName;
+
+  /// Description/subtitle text className.
+  ///
+  /// Defaults to `'text-sm text-gray-600 dark:text-gray-400'`.
+  final String descriptionClassName;
+
+  /// Primary action button className.
+  ///
+  /// Defaults to
+  /// `'px-4 py-2 rounded-lg bg-primary hover:bg-primary/80 text-white text-sm font-medium'`.
+  final String primaryButtonClassName;
+
+  /// Secondary/cancel action button className.
+  ///
+  /// Defaults to
+  /// `'px-4 py-2 rounded-lg bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-200 text-sm font-medium'`.
+  final String secondaryButtonClassName;
+
+  /// Destructive/danger action button className.
+  ///
+  /// Defaults to
+  /// `'px-4 py-2 rounded-lg bg-red-500 hover:bg-red-600 text-white text-sm font-medium'`.
+  final String dangerButtonClassName;
+
+  /// Warning action button className.
+  ///
+  /// Defaults to
+  /// `'px-4 py-2 rounded-lg bg-amber-500 hover:bg-amber-600 text-white text-sm font-medium'`.
+  final String warningButtonClassName;
+
+  /// Inline error message text className.
+  ///
+  /// Defaults to `'text-sm text-red-600 dark:text-red-400'`.
+  final String errorClassName;
+
+  /// Text input field className.
+  ///
+  /// Defaults to
+  /// `'w-full px-3 py-3 rounded-lg bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 text-gray-900 dark:text-white focus:border-primary'`.
+  final String inputClassName;
+
+  /// Maximum width of the modal dialog in logical pixels.
+  ///
+  /// Defaults to `448.0`.
+  final double maxWidth;
+
+  const MagicStarterModalTheme({
+    this.containerClassName = 'bg-white dark:bg-gray-800 rounded-2xl',
+    this.headerClassName = 'px-6 pt-6 pb-4',
+    this.bodyClassName = 'px-6 pb-4',
+    this.footerClassName = 'px-6 py-4 bg-gray-50 dark:bg-gray-800/50',
+    this.titleClassName =
+        'text-xl font-semibold text-gray-900 dark:text-white mb-2',
+    this.descriptionClassName = 'text-sm text-gray-600 dark:text-gray-400',
+    this.primaryButtonClassName =
+        'px-4 py-2 rounded-lg bg-primary hover:bg-primary/80 text-white text-sm font-medium',
+    this.secondaryButtonClassName =
+        'px-4 py-2 rounded-lg bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-200 text-sm font-medium',
+    this.dangerButtonClassName =
+        'px-4 py-2 rounded-lg bg-red-500 hover:bg-red-600 text-white text-sm font-medium',
+    this.warningButtonClassName =
+        'px-4 py-2 rounded-lg bg-amber-500 hover:bg-amber-600 text-white text-sm font-medium',
+    this.errorClassName = 'text-sm text-red-600 dark:text-red-400',
+    this.inputClassName =
+        'w-full px-3 py-3 rounded-lg bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 text-gray-900 dark:text-white focus:border-primary',
+    this.maxWidth = 448.0,
+  });
+}
+
 /// Configuration for app navigation sections.
 ///
 /// Apps register these via [MagicStarter.useNavigation] to populate
@@ -206,6 +322,10 @@ class MagicStarterManager {
   /// app layout navigation elements (active item, brand, bottom nav, avatar).
   MagicStarterNavigationTheme navigationTheme =
       const MagicStarterNavigationTheme();
+
+  /// Modal theme configuration. Holds className overrides for modal containers,
+  /// headers, bodies, footers, buttons, inputs, and typography.
+  MagicStarterModalTheme modalTheme = const MagicStarterModalTheme();
 
   /// Native language names for common locale codes.
   /// Used to generate human-readable labels from [Lang.supportedLocales].
@@ -331,6 +451,22 @@ class MagicStarterManager {
       'layout.app',
       (child) => MagicStarterAppLayout(child: child),
     );
+    // Modals
+    _registerDefaultModal(
+      'modal.confirm',
+      () => const MagicStarterConfirmDialog(title: ''),
+    );
+    _registerDefaultModal(
+      'modal.password_confirm',
+      () => const MagicStarterPasswordConfirmDialog(),
+    );
+    _registerDefaultModal(
+      'modal.two_factor',
+      () => MagicStarterTwoFactorModal(
+        setupData: const {},
+        onConfirm: (_) async => false,
+      ),
+    );
   }
 
   void _registerDefault(String key, Widget Function() builder) {
@@ -342,6 +478,12 @@ class MagicStarterManager {
   void _registerDefaultLayout(String key, Widget Function(Widget) builder) {
     if (!_viewRegistry.hasLayout(key)) {
       _viewRegistry.registerLayout(key, builder);
+    }
+  }
+
+  void _registerDefaultModal(String key, Widget Function() builder) {
+    if (!_viewRegistry.hasModal(key)) {
+      _viewRegistry.registerModal(key, builder);
     }
   }
 
@@ -367,6 +509,7 @@ class MagicStarterManager {
     socialLoginBuilder = null;
     notificationTypeMapper = null;
     navigationTheme = const MagicStarterNavigationTheme();
+    modalTheme = const MagicStarterModalTheme();
     _localeOptions = null;
     guestAuthEntryBuilder = null;
     newsletterLabel = null;

--- a/lib/src/magic_starter_manager.dart
+++ b/lib/src/magic_starter_manager.dart
@@ -454,7 +454,7 @@ class MagicStarterManager {
     // Modals
     _registerDefaultModal(
       'modal.confirm',
-      () => const MagicStarterConfirmDialog(title: ''),
+      () => MagicStarterConfirmDialog(title: trans('common.confirm')),
     );
     _registerDefaultModal(
       'modal.password_confirm',

--- a/lib/src/ui/magic_starter_view_registry.dart
+++ b/lib/src/ui/magic_starter_view_registry.dart
@@ -2,6 +2,7 @@ import 'package:flutter/widgets.dart';
 
 typedef MagicStarterViewBuilder = Widget Function();
 typedef MagicStarterLayoutBuilder = Widget Function(Widget child);
+typedef MagicStarterModalBuilder = Widget Function();
 
 /// Registry for starter view builders.
 ///
@@ -11,6 +12,8 @@ class MagicStarterViewRegistry {
       <String, MagicStarterViewBuilder>{};
   final Map<String, MagicStarterLayoutBuilder> _layouts =
       <String, MagicStarterLayoutBuilder>{};
+  final Map<String, MagicStarterModalBuilder> _modals =
+      <String, MagicStarterModalBuilder>{};
 
   /// Register a builder under the given key.
   void register(String key, MagicStarterViewBuilder builder) {
@@ -54,9 +57,31 @@ class MagicStarterViewRegistry {
     return builder(child);
   }
 
+  /// Register a modal builder under the given key.
+  void registerModal(String key, MagicStarterModalBuilder builder) {
+    _modals[key] = builder;
+  }
+
+  /// Returns true when a modal builder exists for [key].
+  bool hasModal(String key) => _modals.containsKey(key);
+
+  /// Build a modal widget by [key].
+  ///
+  /// Throws [StateError] when the key is not registered.
+  Widget makeModal(String key) {
+    final builder = _modals[key];
+
+    if (builder == null) {
+      throw StateError('No modal builder registered for key "$key".');
+    }
+
+    return builder();
+  }
+
   /// Remove all builders (useful for tests).
   void clear() {
     _builders.clear();
     _layouts.clear();
+    _modals.clear();
   }
 }

--- a/lib/src/ui/views/teams/magic_starter_team_settings_view.dart
+++ b/lib/src/ui/views/teams/magic_starter_team_settings_view.dart
@@ -3,8 +3,9 @@ import 'package:magic/magic.dart';
 
 import '../../../configuration/magic_starter_config.dart';
 import '../../../http/controllers/magic_starter_team_controller.dart';
-import '../../widgets/magic_starter_page_header.dart';
 import '../../widgets/magic_starter_card.dart';
+import '../../widgets/magic_starter_confirm_dialog.dart';
+import '../../widgets/magic_starter_page_header.dart';
 
 class MagicStarterTeamSettingsView
     extends MagicStatefulView<MagicStarterTeamController> {
@@ -320,24 +321,12 @@ class _MagicStarterTeamSettingsViewState extends MagicStatefulViewState<
             if (!isOwner)
               WAnchor(
                 onTap: () async {
-                  final confirmed = await showDialog<bool>(
-                    context: context,
-                    builder: (ctx) => AlertDialog(
-                      title: Text(trans('teams.remove_member_label')),
-                      content: Text(trans('teams.confirm_remove_member')),
-                      actions: [
-                        TextButton(
-                          onPressed: () => Navigator.of(ctx).pop(false),
-                          child: Text(trans('common.cancel')),
-                        ),
-                        TextButton(
-                          onPressed: () => Navigator.of(ctx).pop(true),
-                          style:
-                              TextButton.styleFrom(foregroundColor: Colors.red),
-                          child: Text(trans('teams.remove_member_label')),
-                        ),
-                      ],
-                    ),
+                  final confirmed = await MagicStarterConfirmDialog.show(
+                    context,
+                    title: trans('teams.remove_member_label'),
+                    description: trans('teams.confirm_remove_member'),
+                    confirmLabel: trans('teams.remove'),
+                    variant: ConfirmDialogVariant.danger,
                   );
                   if (confirmed == true) {
                     controller.removeMember(memberId);
@@ -407,24 +396,11 @@ class _MagicStarterTeamSettingsViewState extends MagicStatefulViewState<
             ),
             WAnchor(
               onTap: () async {
-                final confirmed = await showDialog<bool>(
-                  context: context,
-                  builder: (ctx) => AlertDialog(
-                    title: Text(trans('teams.cancel_invite_label')),
-                    content: Text(trans('teams.confirm_cancel_invite')),
-                    actions: [
-                      TextButton(
-                        onPressed: () => Navigator.of(ctx).pop(false),
-                        child: Text(trans('common.cancel')),
-                      ),
-                      TextButton(
-                        onPressed: () => Navigator.of(ctx).pop(true),
-                        style:
-                            TextButton.styleFrom(foregroundColor: Colors.red),
-                        child: Text(trans('teams.cancel_invite_label')),
-                      ),
-                    ],
-                  ),
+                final confirmed = await MagicStarterConfirmDialog.show(
+                  context,
+                  title: trans('teams.cancel_invite_label'),
+                  description: trans('teams.confirm_cancel_invite'),
+                  variant: ConfirmDialogVariant.danger,
                 );
                 if (confirmed == true) {
                   controller.cancelInvitation(invitationId);

--- a/lib/src/ui/widgets/magic_starter_confirm_dialog.dart
+++ b/lib/src/ui/widgets/magic_starter_confirm_dialog.dart
@@ -1,0 +1,149 @@
+import 'package:flutter/material.dart';
+import 'package:magic/magic.dart';
+
+import '../../facades/magic_starter.dart';
+import 'magic_starter_dialog_shell.dart';
+
+/// Visual style variants for [MagicStarterConfirmDialog].
+enum ConfirmDialogVariant {
+  /// Default confirmation with primary-colored button.
+  primary,
+
+  /// Destructive action with red button.
+  danger,
+
+  /// Cautionary action with amber button.
+  warning,
+}
+
+/// A reusable confirm/cancel dialog built on [MagicStarterDialogShell].
+///
+/// Supports three visual variants ([ConfirmDialogVariant]) and an optional
+/// async [onConfirm] callback with double-click protection via [_isLoading].
+///
+/// Returns `true` on confirm, `false` on cancel.
+class MagicStarterConfirmDialog extends StatefulWidget {
+  /// Dialog heading text.
+  final String title;
+
+  /// Optional supporting text rendered below the title.
+  final String? description;
+
+  /// Label for the confirm button. Defaults to `trans('common.confirm')`.
+  final String? confirmLabel;
+
+  /// Label for the cancel button. Defaults to `trans('common.cancel')`.
+  final String? cancelLabel;
+
+  /// Visual variant that controls the confirm button colour.
+  final ConfirmDialogVariant variant;
+
+  /// Optional async callback invoked when the user taps the confirm button.
+  final Future<void> Function()? onConfirm;
+
+  const MagicStarterConfirmDialog({
+    super.key,
+    required this.title,
+    this.description,
+    this.confirmLabel,
+    this.cancelLabel,
+    this.variant = ConfirmDialogVariant.primary,
+    this.onConfirm,
+  });
+
+  /// Opens the dialog and returns `true` if confirmed, `false` if cancelled.
+  static Future<bool> show(
+    BuildContext context, {
+    required String title,
+    String? description,
+    String? confirmLabel,
+    String? cancelLabel,
+    ConfirmDialogVariant variant = ConfirmDialogVariant.primary,
+    Future<void> Function()? onConfirm,
+  }) {
+    return showDialog<bool>(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => MagicStarterConfirmDialog(
+        title: title,
+        description: description,
+        confirmLabel: confirmLabel,
+        cancelLabel: cancelLabel,
+        variant: variant,
+        onConfirm: onConfirm,
+      ),
+    ).then((v) => v ?? false);
+  }
+
+  @override
+  State<MagicStarterConfirmDialog> createState() =>
+      _MagicStarterConfirmDialogState();
+}
+
+class _MagicStarterConfirmDialogState extends State<MagicStarterConfirmDialog> {
+  bool _isLoading = false;
+
+  Future<void> _onConfirm() async {
+    if (_isLoading) return;
+
+    setState(() => _isLoading = true);
+
+    await widget.onConfirm?.call();
+
+    if (!mounted) return;
+
+    Navigator.of(context).pop(true);
+  }
+
+  void _onCancel() {
+    if (_isLoading) return;
+    Navigator.of(context).pop(false);
+  }
+
+  String _resolveConfirmClassName() {
+    final theme = MagicStarter.manager.modalTheme;
+
+    return switch (widget.variant) {
+      ConfirmDialogVariant.primary => theme.primaryButtonClassName,
+      ConfirmDialogVariant.danger => theme.dangerButtonClassName,
+      ConfirmDialogVariant.warning => theme.warningButtonClassName,
+    };
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = MagicStarter.manager.modalTheme;
+    final confirmLabel = widget.confirmLabel ?? trans('common.confirm');
+    final cancelLabel = widget.cancelLabel ?? trans('common.cancel');
+
+    return MagicStarterDialogShell(
+      title: widget.title,
+      description: widget.description,
+      body: const SizedBox.shrink(),
+      footer: WDiv(
+        className: 'flex flex-row gap-2 w-full',
+        children: [
+          WDiv(
+            className: 'flex-1',
+            child: WAnchor(
+              onTap: _isLoading ? null : _onCancel,
+              child: WDiv(
+                className: theme.secondaryButtonClassName,
+                child: WText(cancelLabel),
+              ),
+            ),
+          ),
+          WDiv(
+            className: 'flex-1',
+            child: WButton(
+              onTap: _isLoading ? null : _onConfirm,
+              isLoading: _isLoading,
+              className: 'w-full ${_resolveConfirmClassName()}',
+              child: WText(confirmLabel),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/ui/widgets/magic_starter_confirm_dialog.dart
+++ b/lib/src/ui/widgets/magic_starter_confirm_dialog.dart
@@ -88,7 +88,14 @@ class _MagicStarterConfirmDialogState extends State<MagicStarterConfirmDialog> {
 
     setState(() => _isLoading = true);
 
-    await widget.onConfirm?.call();
+    try {
+      await widget.onConfirm?.call();
+    } catch (e, stackTrace) {
+      Log.error('[MagicStarterConfirmDialog._onConfirm] $e\n$stackTrace');
+      if (!mounted) return;
+      setState(() => _isLoading = false);
+      return;
+    }
 
     if (!mounted) return;
 

--- a/lib/src/ui/widgets/magic_starter_dialog_shell.dart
+++ b/lib/src/ui/widgets/magic_starter_dialog_shell.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:magic/magic.dart';
+
+import '../../facades/magic_starter.dart';
+
+/// Internal dialog shell — NOT exported from barrel.
+/// Provides consistent Dialog chrome with sticky header/footer and scrollable body.
+class MagicStarterDialogShell extends StatelessWidget {
+  final String? title;
+  final String? description;
+  final Widget body;
+  final Widget? footer;
+
+  const MagicStarterDialogShell({
+    super.key,
+    this.title,
+    this.description,
+    required this.body,
+    this.footer,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = MagicStarter.manager.modalTheme;
+
+    return Dialog(
+      backgroundColor: Colors.transparent,
+      insetPadding: const EdgeInsets.symmetric(horizontal: 16),
+      child: ConstrainedBox(
+        constraints: BoxConstraints(
+          maxWidth: theme.maxWidth,
+          maxHeight: MediaQuery.sizeOf(context).height * 0.85,
+        ),
+        child: WDiv(
+          className:
+              '${theme.containerClassName} flex flex-col w-full overflow-hidden',
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              if (title != null || description != null)
+                WDiv(
+                  className: theme.headerClassName,
+                  children: [
+                    if (title != null)
+                      WText(
+                        title!,
+                        className: theme.titleClassName,
+                      ),
+                    if (description != null)
+                      WText(
+                        description!,
+                        className: theme.descriptionClassName,
+                      ),
+                  ],
+                ),
+              Flexible(
+                child: SingleChildScrollView(
+                  child: WDiv(
+                    className: theme.bodyClassName,
+                    child: body,
+                  ),
+                ),
+              ),
+              if (footer != null)
+                WDiv(
+                  key: const Key('magic_starter_dialog_shell_footer'),
+                  className: theme.footerClassName,
+                  child: footer,
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/ui/widgets/magic_starter_password_confirm_dialog.dart
+++ b/lib/src/ui/widgets/magic_starter_password_confirm_dialog.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:magic/magic.dart';
 
+import '../../facades/magic_starter.dart';
+
 /// A reusable dialog widget that prompts the user to confirm their password.
 ///
 /// This dialog maintains its own standalone state for the password input,
@@ -106,39 +108,40 @@ class _MagicStarterPasswordConfirmDialogState
 
   @override
   Widget build(BuildContext context) {
+    final theme = MagicStarter.manager.modalTheme;
+
     return Dialog(
       backgroundColor: Colors.transparent,
       insetPadding: const EdgeInsets.symmetric(horizontal: 16),
       child: ConstrainedBox(
-        constraints: const BoxConstraints(
-          maxWidth: 448,
+        constraints: BoxConstraints(
+          maxWidth: theme.maxWidth,
           maxHeight: 600,
         ),
         child: SingleChildScrollView(
           child: WDiv(
             className:
-                'bg-white dark:bg-gray-800 rounded-2xl flex flex-col w-full overflow-hidden',
+                '${theme.containerClassName} flex flex-col w-full overflow-hidden',
             children: [
               // Header
               WDiv(
-                className: 'px-6 pt-6 pb-4',
+                className: theme.headerClassName,
                 children: [
                   WText(
                     widget.title ?? trans('profile.confirm_password'),
-                    className:
-                        'text-xl font-semibold text-gray-900 dark:text-white mb-2',
+                    className: theme.titleClassName,
                   ),
                   WText(
                     widget.description ??
                         trans('profile.confirm_password_description'),
-                    className: 'text-sm text-gray-600 dark:text-gray-400',
+                    className: theme.descriptionClassName,
                   ),
                 ],
               ),
 
               // Body
               WDiv(
-                className: 'px-6 pb-4',
+                className: theme.bodyClassName,
                 children: [
                   WFormInput(
                     controller: _passwordController,
@@ -150,8 +153,7 @@ class _MagicStarterPasswordConfirmDialogState
                         className: 'text-gray-400 text-xl',
                       ),
                     ),
-                    className:
-                        'w-full px-3 py-3 rounded-lg bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 text-gray-900 dark:text-white focus:border-primary error:border-red-500',
+                    className: '${theme.inputClassName} error:border-red-500',
                   ),
                 ],
               ),
@@ -159,17 +161,17 @@ class _MagicStarterPasswordConfirmDialogState
               // Inline error message (from async onConfirm)
               if (_errorMessage != null)
                 WDiv(
-                  className: 'px-6 pb-4',
+                  className: theme.bodyClassName,
                   child: WText(
                     _errorMessage!,
-                    className: 'text-sm text-red-600 dark:text-red-400',
+                    className: theme.errorClassName,
                   ),
                 ),
 
               // Footer
               WDiv(
                 className:
-                    'px-6 py-4 bg-gray-50 dark:bg-gray-800/50 flex flex-row gap-2 w-full',
+                    '${theme.footerClassName} flex flex-row gap-2 w-full',
                 children: [
                   WDiv(
                     className: 'flex-1',
@@ -177,7 +179,7 @@ class _MagicStarterPasswordConfirmDialogState
                       onTap: _isLoading ? null : _onCancel,
                       child: WDiv(
                         className:
-                            'px-4 py-2 rounded-lg bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-200 text-sm font-medium text-center',
+                            '${theme.secondaryButtonClassName} text-center',
                         child: WText(trans('common.cancel')),
                       ),
                     ),
@@ -188,7 +190,7 @@ class _MagicStarterPasswordConfirmDialogState
                       onTap: _isLoading ? null : _onConfirm,
                       isLoading: _isLoading,
                       className:
-                          'w-full px-4 py-2 rounded-lg bg-primary hover:bg-primary/80 text-white text-sm font-medium text-center',
+                          'w-full ${theme.primaryButtonClassName} text-center',
                       child: WText(trans('common.confirm')),
                     ),
                   ),

--- a/lib/src/ui/widgets/magic_starter_two_factor_modal.dart
+++ b/lib/src/ui/widgets/magic_starter_two_factor_modal.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:magic/magic.dart';
 
+import '../../facades/magic_starter.dart';
+
 /// A multi-step wizard modal widget for Two-Factor Authentication (2FA) setup.
 ///
 /// Handles displaying the QR code, confirming the initial OTP, and subsequently
@@ -108,6 +110,7 @@ class _MagicStarterTwoFactorModalState
   }
 
   Widget _buildSetupStep() {
+    final theme = MagicStarter.manager.modalTheme;
     final qrSvg = widget.setupData['qr_svg'] as String?;
     final secret = widget.setupData['secret'] as String?;
 
@@ -116,7 +119,7 @@ class _MagicStarterTwoFactorModalState
       children: [
         WText(
           trans('profile.two_factor_setup_description'),
-          className: 'text-sm text-gray-600 dark:text-gray-400',
+          className: theme.descriptionClassName,
         ),
         if (qrSvg != null && qrSvg.isNotEmpty)
           WDiv(
@@ -152,13 +155,12 @@ class _MagicStarterTwoFactorModalState
           type: InputType.number,
           labelClassName:
               'text-sm font-medium text-gray-700 dark:text-gray-300 mb-1',
-          className:
-              'w-full px-3 py-3 rounded-lg bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 text-gray-900 dark:text-white focus:border-primary',
+          className: theme.inputClassName,
         ),
         if (_errorMessage != null)
           WText(
             _errorMessage!,
-            className: 'text-red-500 dark:text-red-400 text-sm',
+            className: theme.errorClassName,
           ),
         WDiv(
           className: 'flex flex-row justify-end gap-2 wrap mt-2',
@@ -166,16 +168,14 @@ class _MagicStarterTwoFactorModalState
             WAnchor(
               onTap: _handleCancel,
               child: WDiv(
-                className:
-                    'px-4 py-2 rounded-lg bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-200 text-sm font-medium',
+                className: theme.secondaryButtonClassName,
                 child: WText(trans('common.cancel')),
               ),
             ),
             WButton(
               onTap: _isLoading ? null : _handleConfirm,
               isLoading: _isLoading,
-              className:
-                  'px-4 py-2 rounded-lg bg-primary hover:bg-primary/80 text-white text-sm font-medium',
+              className: theme.primaryButtonClassName,
               child: WText(trans('common.confirm')),
             ),
           ],
@@ -185,6 +185,7 @@ class _MagicStarterTwoFactorModalState
   }
 
   Widget _buildRecoveryStep() {
+    final theme = MagicStarter.manager.modalTheme;
     final recoveryCodes = (widget.setupData['recovery_codes'] as List<dynamic>?)
             ?.map((e) => e.toString())
             .toList() ??
@@ -195,7 +196,7 @@ class _MagicStarterTwoFactorModalState
       children: [
         WText(
           trans('profile.two_factor_recovery_codes_description'),
-          className: 'text-sm text-gray-600 dark:text-gray-400',
+          className: theme.descriptionClassName,
         ),
         WDiv(
           className: 'wrap gap-2',
@@ -232,8 +233,7 @@ class _MagicStarterTwoFactorModalState
           children: [
             WButton(
               onTap: _handleDone,
-              className:
-                  'px-4 py-2 rounded-lg bg-primary hover:bg-primary/80 text-white text-sm font-medium',
+              className: theme.primaryButtonClassName,
               child: WText(trans('common.done')),
             ),
           ],
@@ -244,26 +244,27 @@ class _MagicStarterTwoFactorModalState
 
   @override
   Widget build(BuildContext context) {
+    final theme = MagicStarter.manager.modalTheme;
+
     return Dialog(
       backgroundColor: Colors.transparent,
       insetPadding: const EdgeInsets.symmetric(horizontal: 16),
       child: ConstrainedBox(
-        constraints: const BoxConstraints(
-          maxWidth: 448,
+        constraints: BoxConstraints(
+          maxWidth: theme.maxWidth,
           maxHeight: 800,
         ),
         child: SingleChildScrollView(
           child: WDiv(
             className:
-                'bg-white dark:bg-gray-800 rounded-2xl flex flex-col w-full overflow-hidden',
+                '${theme.containerClassName} flex flex-col w-full overflow-hidden',
             children: [
               WDiv(
-                className: 'px-6 pt-6 pb-4',
+                className: theme.headerClassName,
                 children: [
                   WText(
                     trans('profile.two_factor_auth'),
-                    className:
-                        'text-xl font-semibold text-gray-900 dark:text-white mb-2',
+                    className: theme.titleClassName,
                   ),
                 ],
               ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: magic_starter
 description: Starter kit for Magic Framework. Auth, Profile, Teams, Notifications — 13 opt-in features with overridable views.
-version: 0.0.1-alpha.3
+version: 0.0.1-alpha.4
 homepage: https://magic.fluttersdk.com/starter
 documentation: https://magic.fluttersdk.com/packages/starter/getting-started/installation
 repository: https://github.com/fluttersdk/magic_starter

--- a/test/facades/magic_starter_facade_test.dart
+++ b/test/facades/magic_starter_facade_test.dart
@@ -170,5 +170,193 @@ void main() {
         );
       });
     });
+
+    group('modal theme', () {
+      test('modalTheme returns default instance when not configured', () {
+        final theme = MagicStarter.modalTheme;
+
+        expect(
+          theme.containerClassName,
+          'bg-white dark:bg-gray-800 rounded-2xl',
+        );
+        expect(
+          theme.headerClassName,
+          'px-6 pt-6 pb-4',
+        );
+        expect(
+          theme.bodyClassName,
+          'px-6 pb-4',
+        );
+        expect(
+          theme.footerClassName,
+          'px-6 py-4 bg-gray-50 dark:bg-gray-800/50',
+        );
+        expect(
+          theme.titleClassName,
+          'text-xl font-semibold text-gray-900 dark:text-white mb-2',
+        );
+        expect(
+          theme.descriptionClassName,
+          'text-sm text-gray-600 dark:text-gray-400',
+        );
+        expect(
+          theme.primaryButtonClassName,
+          'px-4 py-2 rounded-lg bg-primary hover:bg-primary/80 text-white text-sm font-medium',
+        );
+        expect(
+          theme.secondaryButtonClassName,
+          'px-4 py-2 rounded-lg bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-200 text-sm font-medium',
+        );
+        expect(
+          theme.dangerButtonClassName,
+          'px-4 py-2 rounded-lg bg-red-500 hover:bg-red-600 text-white text-sm font-medium',
+        );
+        expect(
+          theme.warningButtonClassName,
+          'px-4 py-2 rounded-lg bg-amber-500 hover:bg-amber-600 text-white text-sm font-medium',
+        );
+        expect(
+          theme.errorClassName,
+          'text-sm text-red-600 dark:text-red-400',
+        );
+        expect(
+          theme.inputClassName,
+          'w-full px-3 py-3 rounded-lg bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 text-gray-900 dark:text-white focus:border-primary',
+        );
+        expect(theme.maxWidth, 448.0);
+      });
+
+      test('useModalTheme() stores theme on manager', () {
+        const customTheme = MagicStarterModalTheme(
+          containerClassName: 'bg-gray-900 rounded-xl',
+        );
+
+        MagicStarter.useModalTheme(customTheme);
+
+        expect(MagicStarter.manager.modalTheme, equals(customTheme));
+      });
+
+      test('modalTheme getter returns the registered theme', () {
+        const customTheme = MagicStarterModalTheme(
+          containerClassName: 'bg-slate-800 rounded-3xl',
+          titleClassName: 'text-2xl font-bold text-white',
+        );
+
+        MagicStarter.useModalTheme(customTheme);
+
+        expect(MagicStarter.modalTheme, equals(customTheme));
+        expect(
+          MagicStarter.modalTheme.containerClassName,
+          'bg-slate-800 rounded-3xl',
+        );
+        expect(
+          MagicStarter.modalTheme.titleClassName,
+          'text-2xl font-bold text-white',
+        );
+      });
+
+      test('MagicStarterModalTheme preserves all custom field values', () {
+        const customContainer =
+            'bg-zinc-900 rounded-2xl border border-zinc-700';
+        const customHeader = 'px-8 pt-8 pb-6';
+        const customBody = 'px-8 pb-6';
+        const customFooter = 'px-8 py-6 bg-zinc-800';
+        const customTitle = 'text-2xl font-black text-white';
+        const customDescription = 'text-base text-zinc-400';
+        const customPrimary =
+            'px-6 py-3 rounded-xl bg-indigo-600 hover:bg-indigo-700 text-white font-semibold';
+        const customSecondary =
+            'px-6 py-3 rounded-xl bg-zinc-700 hover:bg-zinc-600 text-white font-semibold';
+        const customDanger =
+            'px-6 py-3 rounded-xl bg-rose-600 hover:bg-rose-700 text-white font-semibold';
+        const customWarning =
+            'px-6 py-3 rounded-xl bg-yellow-500 hover:bg-yellow-600 text-white font-semibold';
+        const customError = 'text-base text-rose-400';
+        const customInput =
+            'w-full px-4 py-4 rounded-xl bg-zinc-800 border border-zinc-600 text-white';
+        const customMaxWidth = 560.0;
+
+        const theme = MagicStarterModalTheme(
+          containerClassName: customContainer,
+          headerClassName: customHeader,
+          bodyClassName: customBody,
+          footerClassName: customFooter,
+          titleClassName: customTitle,
+          descriptionClassName: customDescription,
+          primaryButtonClassName: customPrimary,
+          secondaryButtonClassName: customSecondary,
+          dangerButtonClassName: customDanger,
+          warningButtonClassName: customWarning,
+          errorClassName: customError,
+          inputClassName: customInput,
+          maxWidth: customMaxWidth,
+        );
+
+        expect(theme.containerClassName, customContainer);
+        expect(theme.headerClassName, customHeader);
+        expect(theme.bodyClassName, customBody);
+        expect(theme.footerClassName, customFooter);
+        expect(theme.titleClassName, customTitle);
+        expect(theme.descriptionClassName, customDescription);
+        expect(theme.primaryButtonClassName, customPrimary);
+        expect(theme.secondaryButtonClassName, customSecondary);
+        expect(theme.dangerButtonClassName, customDanger);
+        expect(theme.warningButtonClassName, customWarning);
+        expect(theme.errorClassName, customError);
+        expect(theme.inputClassName, customInput);
+        expect(theme.maxWidth, customMaxWidth);
+      });
+
+      test('manager reset() restores default modal theme', () {
+        MagicStarter.useModalTheme(
+          const MagicStarterModalTheme(
+            containerClassName: 'bg-custom rounded-none',
+          ),
+        );
+
+        expect(
+          MagicStarter.modalTheme.containerClassName,
+          'bg-custom rounded-none',
+        );
+
+        MagicStarter.manager.reset();
+
+        expect(
+          MagicStarter.modalTheme.containerClassName,
+          'bg-white dark:bg-gray-800 rounded-2xl',
+        );
+      });
+    });
+
+    group('modal registry defaults', () {
+      test('default modal.confirm is registered after manager init', () {
+        expect(MagicStarter.view.hasModal('modal.confirm'), isTrue);
+      });
+
+      test('default modal.password_confirm is registered', () {
+        expect(MagicStarter.view.hasModal('modal.password_confirm'), isTrue);
+      });
+
+      test('default modal.two_factor is registered', () {
+        expect(MagicStarter.view.hasModal('modal.two_factor'), isTrue);
+      });
+
+      test(
+          'manager.reset() clears consumer overrides and re-registers defaults',
+          () {
+        // Consumer override is lost on reset — default is re-registered
+        MagicStarter.view
+            .registerModal('modal.confirm', () => const SizedBox());
+        MagicStarter.manager.reset();
+        expect(MagicStarter.view.hasModal('modal.confirm'), isTrue);
+      });
+
+      test('manager.reset() re-registers default modals', () {
+        MagicStarter.manager.reset();
+        expect(MagicStarter.view.hasModal('modal.confirm'), isTrue);
+        expect(MagicStarter.view.hasModal('modal.password_confirm'), isTrue);
+        expect(MagicStarter.view.hasModal('modal.two_factor'), isTrue);
+      });
+    });
   });
 }

--- a/test/ui/magic_starter_view_registry_test.dart
+++ b/test/ui/magic_starter_view_registry_test.dart
@@ -160,5 +160,75 @@ void main() {
         );
       });
     });
+
+    // -------------------------------------------------------------------------
+    // modal registry
+    // -------------------------------------------------------------------------
+
+    group('modal registry', () {
+      test(
+          'registerModal() stores a builder that can be retrieved via makeModal()',
+          () {
+        const expected = SizedBox(key: Key('modal-widget'));
+        registry.registerModal('confirm', () => expected);
+
+        final Widget result = registry.makeModal('confirm');
+
+        expect(result, same(expected));
+      });
+
+      test('hasModal() returns true for registered key', () {
+        registry.registerModal('confirm', () => const SizedBox());
+
+        expect(registry.hasModal('confirm'), isTrue);
+      });
+
+      test('hasModal() returns false for unregistered key', () {
+        expect(registry.hasModal('non-existent'), isFalse);
+      });
+
+      test('makeModal() returns widget from registered builder', () {
+        registry.registerModal('alert', () => const Placeholder());
+
+        final Widget result = registry.makeModal('alert');
+
+        expect(result, isA<Placeholder>());
+      });
+
+      test('makeModal() throws StateError for unregistered key', () {
+        expect(
+          () => registry.makeModal('missing'),
+          throwsA(
+            isA<StateError>().having(
+              (e) => e.message,
+              'message',
+              contains('missing'),
+            ),
+          ),
+        );
+      });
+
+      test(
+          'clear() clears modal builders — hasModal() returns false after clear()',
+          () {
+        registry.registerModal('confirm', () => const SizedBox());
+        registry.registerModal('alert', () => const Placeholder());
+
+        registry.clear();
+
+        expect(registry.hasModal('confirm'), isFalse);
+        expect(registry.hasModal('alert'), isFalse);
+      });
+
+      test('makeModal() throws after clear()', () {
+        registry.registerModal('confirm', () => const SizedBox());
+        registry.clear();
+
+        expect(
+          () => registry.makeModal('confirm'),
+          throwsA(isA<StateError>()),
+        );
+      });
+    });
   });
 }

--- a/test/ui/views/teams/magic_starter_team_settings_view_test.dart
+++ b/test/ui/views/teams/magic_starter_team_settings_view_test.dart
@@ -1,0 +1,187 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:magic/magic.dart';
+import 'package:magic_starter/magic_starter.dart';
+
+class MockNetworkDriver implements NetworkDriver {
+  MagicResponse? nextResponse;
+
+  void mockResponse({required int statusCode, dynamic data}) {
+    nextResponse = MagicResponse(
+      data: data ?? {},
+      statusCode: statusCode,
+    );
+  }
+
+  @override
+  Future<MagicResponse> get(String url,
+          {Map<String, dynamic>? query, Map<String, String>? headers}) async =>
+      nextResponse ?? MagicResponse(data: {}, statusCode: 200);
+  @override
+  void addInterceptor(MagicNetworkInterceptor interceptor) {}
+  @override
+  Future<MagicResponse> post(String url,
+          {dynamic data, Map<String, String>? headers}) async =>
+      nextResponse ?? MagicResponse(data: {}, statusCode: 200);
+  @override
+  Future<MagicResponse> put(String url,
+          {dynamic data, Map<String, String>? headers}) async =>
+      nextResponse ?? MagicResponse(data: {}, statusCode: 200);
+  @override
+  Future<MagicResponse> delete(String url,
+          {Map<String, String>? headers}) async =>
+      nextResponse ?? MagicResponse(data: {}, statusCode: 200);
+  @override
+  Future<MagicResponse> index(String resource,
+          {Map<String, dynamic>? filters,
+          Map<String, String>? headers}) async =>
+      nextResponse ?? MagicResponse(data: {}, statusCode: 200);
+  @override
+  Future<MagicResponse> show(String resource, String id,
+          {Map<String, String>? headers}) async =>
+      nextResponse ?? MagicResponse(data: {}, statusCode: 200);
+  @override
+  Future<MagicResponse> store(String resource, Map<String, dynamic> data,
+          {Map<String, String>? headers}) async =>
+      nextResponse ?? MagicResponse(data: {}, statusCode: 200);
+  @override
+  Future<MagicResponse> update(
+          String resource, String id, Map<String, dynamic> data,
+          {Map<String, String>? headers}) async =>
+      nextResponse ?? MagicResponse(data: {}, statusCode: 200);
+  @override
+  Future<MagicResponse> destroy(String resource, String id,
+          {Map<String, String>? headers}) async =>
+      nextResponse ?? MagicResponse(data: {}, statusCode: 200);
+  @override
+  Future<MagicResponse> upload(String url,
+          {required Map<String, dynamic> data,
+          required Map<String, dynamic> files,
+          Map<String, String>? headers}) async =>
+      nextResponse ?? MagicResponse(data: {}, statusCode: 200);
+}
+
+void main() {
+  Widget wrap(Widget widget) {
+    final themeData = WindThemeData(
+      colors: {
+        'primary': Colors.indigo,
+        'danger': Colors.red,
+        'warning': Colors.amber,
+      },
+    );
+    return WindTheme(
+      data: themeData,
+      child: MaterialApp(
+        theme: themeData.toThemeData(),
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: SizedBox(
+              width: 1200,
+              height: 2000,
+              child: widget,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  group('MagicStarterTeamSettingsView — confirm dialogs', () {
+    late MagicStarterTeamController controller;
+
+    setUp(() {
+      MagicApp.reset();
+      Magic.flush();
+      Magic.singleton('log', () => LogManager());
+      Magic.singleton('magic_starter', () => MagicStarterManager());
+      Magic.singleton('network', () => MockNetworkDriver());
+      Config.set('magic_starter.features.teams', true);
+      Config.set('wind.colors.primary', 'indigo');
+      controller = MagicStarterTeamController.instance;
+    });
+
+    tearDown(() {
+      controller.members.dispose();
+      controller.invitations.dispose();
+      controller.currentTeamId.dispose();
+    });
+
+    testWidgets(
+        'tapping remove member shows MagicStarterConfirmDialog with danger variant',
+        (tester) async {
+      controller.members.value = [
+        {
+          'id': 1,
+          'name': 'Test User',
+          'email': 'test@example.com',
+          'role': 'member',
+        },
+      ];
+
+      await tester.pumpWidget(wrap(const MagicStarterTeamSettingsView()));
+      await tester.pumpAndSettle();
+
+      // Find the close icon in the member row (remove action)
+      final closeIcons = find.byIcon(Icons.close);
+      expect(closeIcons, findsOneWidget);
+
+      await tester.tap(closeIcons);
+      await tester.pumpAndSettle();
+
+      // Confirm dialog should appear with correct title and description
+      expect(find.text(trans('teams.confirm_remove_member')), findsOneWidget);
+      expect(find.text(trans('teams.remove')), findsOneWidget);
+    });
+
+    testWidgets(
+        'tapping cancel invitation shows MagicStarterConfirmDialog with danger variant',
+        (tester) async {
+      controller.invitations.value = [
+        {
+          'id': 42,
+          'email': 'invite@example.com',
+          'role': 'member',
+        },
+      ];
+
+      await tester.pumpWidget(wrap(const MagicStarterTeamSettingsView()));
+      await tester.pumpAndSettle();
+
+      // Find the close icon in the invitation row (cancel action)
+      final closeIcons = find.byIcon(Icons.close);
+      expect(closeIcons, findsOneWidget);
+
+      await tester.ensureVisible(closeIcons);
+      await tester.pumpAndSettle();
+      await tester.tap(closeIcons);
+      await tester.pumpAndSettle();
+
+      // Confirm dialog should appear
+      expect(find.text(trans('teams.confirm_cancel_invite')), findsOneWidget);
+    });
+
+    testWidgets('no Material AlertDialog is used — uses ConfirmDialog instead',
+        (tester) async {
+      controller.members.value = [
+        {
+          'id': 1,
+          'name': 'Test User',
+          'email': 'test@example.com',
+          'role': 'member',
+        },
+      ];
+
+      await tester.pumpWidget(wrap(const MagicStarterTeamSettingsView()));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.close));
+      await tester.pumpAndSettle();
+
+      // Verify no Material AlertDialog in widget tree
+      expect(find.byType(AlertDialog), findsNothing);
+      // Verify MagicStarterConfirmDialog is used
+      expect(find.byType(MagicStarterConfirmDialog), findsOneWidget);
+    });
+  });
+}

--- a/test/ui/widgets/magic_starter_confirm_dialog_test.dart
+++ b/test/ui/widgets/magic_starter_confirm_dialog_test.dart
@@ -1,0 +1,375 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:magic/magic.dart';
+import 'package:magic_starter/magic_starter.dart';
+
+void main() {
+  setUp(() async {
+    MagicApp.reset();
+    Magic.flush();
+    Magic.singleton('magic_starter', () => MagicStarterManager());
+    Magic.singleton('log', () => LogManager());
+    Config.set('logging', {
+      'default': 'console',
+      'channels': {
+        'console': {'driver': 'console', 'level': 'debug'},
+      },
+    });
+    Config.set('wind.colors.primary', 'indigo');
+  });
+
+  Widget wrap(Widget widget) {
+    final themeData = WindThemeData(
+      colors: {
+        'primary': Colors.indigo,
+        'danger': Colors.red,
+        'warning': Colors.amber,
+      },
+    );
+    return WindTheme(
+      data: themeData,
+      child: MaterialApp(
+        theme: themeData.toThemeData(),
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: SizedBox(
+              width: 1200,
+              height: 800,
+              child: widget,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Rendering
+  // ---------------------------------------------------------------------------
+
+  testWidgets('renders title text', (WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1200, 800);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(() => tester.view.resetPhysicalSize());
+    addTearDown(() => tester.view.resetDevicePixelRatio());
+
+    await tester.pumpWidget(
+      wrap(
+        const MagicStarterConfirmDialog(
+          title: 'Delete item',
+        ),
+      ),
+    );
+
+    expect(find.text('Delete item'), findsOneWidget);
+  });
+
+  testWidgets('renders description text', (WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1200, 800);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(() => tester.view.resetPhysicalSize());
+    addTearDown(() => tester.view.resetDevicePixelRatio());
+
+    await tester.pumpWidget(
+      wrap(
+        const MagicStarterConfirmDialog(
+          title: 'Delete item',
+          description: 'This action cannot be undone.',
+        ),
+      ),
+    );
+
+    expect(find.text('This action cannot be undone.'), findsOneWidget);
+  });
+
+  testWidgets(
+    'renders confirm and cancel buttons with default labels',
+    (WidgetTester tester) async {
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(() => tester.view.resetPhysicalSize());
+      addTearDown(() => tester.view.resetDevicePixelRatio());
+
+      await tester.pumpWidget(
+        wrap(
+          const MagicStarterConfirmDialog(title: 'Confirm?'),
+        ),
+      );
+
+      expect(find.text('common.confirm'), findsOneWidget);
+      expect(find.text('common.cancel'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'renders custom confirm and cancel labels when provided',
+    (WidgetTester tester) async {
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(() => tester.view.resetPhysicalSize());
+      addTearDown(() => tester.view.resetDevicePixelRatio());
+
+      await tester.pumpWidget(
+        wrap(
+          const MagicStarterConfirmDialog(
+            title: 'Remove?',
+            confirmLabel: 'Yes, remove',
+            cancelLabel: 'No, keep it',
+          ),
+        ),
+      );
+
+      expect(find.text('Yes, remove'), findsOneWidget);
+      expect(find.text('No, keep it'), findsOneWidget);
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // Return values
+  // ---------------------------------------------------------------------------
+
+  testWidgets(
+    'returns false when cancel button is tapped',
+    (WidgetTester tester) async {
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(() => tester.view.resetPhysicalSize());
+      addTearDown(() => tester.view.resetDevicePixelRatio());
+
+      bool result = true;
+
+      await tester.pumpWidget(
+        wrap(
+          Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () async {
+                result = await MagicStarterConfirmDialog.show(
+                  context,
+                  title: 'Are you sure?',
+                );
+              },
+              child: const Text('Show'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Show'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('common.cancel'));
+      await tester.pumpAndSettle();
+
+      expect(result, isFalse);
+    },
+  );
+
+  testWidgets(
+    'returns true when confirm button is tapped and onConfirm succeeds',
+    (WidgetTester tester) async {
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(() => tester.view.resetPhysicalSize());
+      addTearDown(() => tester.view.resetDevicePixelRatio());
+
+      bool result = false;
+
+      await tester.pumpWidget(
+        wrap(
+          Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () async {
+                result = await MagicStarterConfirmDialog.show(
+                  context,
+                  title: 'Are you sure?',
+                  onConfirm: () async => null,
+                );
+              },
+              child: const Text('Show'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Show'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('common.confirm'));
+      await tester.pumpAndSettle();
+
+      expect(result, isTrue);
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // Variants
+  // ---------------------------------------------------------------------------
+
+  testWidgets(
+    'default variant is primary',
+    (WidgetTester tester) async {
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(() => tester.view.resetPhysicalSize());
+      addTearDown(() => tester.view.resetDevicePixelRatio());
+
+      await tester.pumpWidget(
+        wrap(
+          const MagicStarterConfirmDialog(title: 'Confirm?'),
+        ),
+      );
+
+      final dialog = tester.widget<MagicStarterConfirmDialog>(
+        find.byType(MagicStarterConfirmDialog),
+      );
+
+      expect(dialog.variant, ConfirmDialogVariant.primary);
+    },
+  );
+
+  testWidgets(
+    'ConfirmDialogVariant.danger renders danger-styled confirm button',
+    (WidgetTester tester) async {
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(() => tester.view.resetPhysicalSize());
+      addTearDown(() => tester.view.resetDevicePixelRatio());
+
+      await tester.pumpWidget(
+        wrap(
+          const MagicStarterConfirmDialog(
+            title: 'Delete?',
+            variant: ConfirmDialogVariant.danger,
+          ),
+        ),
+      );
+
+      // The confirm button should exist and the dialog carries danger variant.
+      final dialog = tester.widget<MagicStarterConfirmDialog>(
+        find.byType(MagicStarterConfirmDialog),
+      );
+
+      expect(dialog.variant, ConfirmDialogVariant.danger);
+      expect(find.text('common.confirm'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'ConfirmDialogVariant.warning renders warning-styled confirm button',
+    (WidgetTester tester) async {
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(() => tester.view.resetPhysicalSize());
+      addTearDown(() => tester.view.resetDevicePixelRatio());
+
+      await tester.pumpWidget(
+        wrap(
+          const MagicStarterConfirmDialog(
+            title: 'Archive?',
+            variant: ConfirmDialogVariant.warning,
+          ),
+        ),
+      );
+
+      final dialog = tester.widget<MagicStarterConfirmDialog>(
+        find.byType(MagicStarterConfirmDialog),
+      );
+
+      expect(dialog.variant, ConfirmDialogVariant.warning);
+      expect(find.text('common.confirm'), findsOneWidget);
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // Static show() factory
+  // ---------------------------------------------------------------------------
+
+  testWidgets(
+    'static show() opens dialog via Builder pattern',
+    (WidgetTester tester) async {
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(() => tester.view.resetPhysicalSize());
+      addTearDown(() => tester.view.resetDevicePixelRatio());
+
+      await tester.pumpWidget(
+        wrap(
+          Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () async {
+                await MagicStarterConfirmDialog.show(
+                  context,
+                  title: 'Are you sure?',
+                  description: 'This cannot be undone.',
+                );
+              },
+              child: const Text('Open'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.byType(MagicStarterConfirmDialog),
+        findsOneWidget,
+      );
+      expect(find.text('Are you sure?'), findsOneWidget);
+      expect(find.text('This cannot be undone.'), findsOneWidget);
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // Theme integration
+  // ---------------------------------------------------------------------------
+
+  testWidgets(
+    'custom MagicStarterModalTheme className appears in dialog',
+    (WidgetTester tester) async {
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(() => tester.view.resetPhysicalSize());
+      addTearDown(() => tester.view.resetDevicePixelRatio());
+
+      MagicStarter.useModalTheme(
+        const MagicStarterModalTheme(
+          containerClassName: 'rounded-3xl bg-white',
+        ),
+      );
+
+      await tester.pumpWidget(
+        wrap(
+          Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () async {
+                await MagicStarterConfirmDialog.show(
+                  context,
+                  title: 'Themed dialog',
+                );
+              },
+              child: const Text('Show'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Show'));
+      await tester.pumpAndSettle();
+
+      // The dialog should open and carry the theme override.
+      expect(find.byType(MagicStarterConfirmDialog), findsOneWidget);
+
+      final dialog = tester.widget<MagicStarterConfirmDialog>(
+        find.byType(MagicStarterConfirmDialog),
+      );
+
+      expect(
+        MagicStarter.modalTheme.containerClassName,
+        'rounded-3xl bg-white',
+      );
+      expect(dialog, isNotNull);
+    },
+  );
+}

--- a/test/ui/widgets/magic_starter_dialog_shell_test.dart
+++ b/test/ui/widgets/magic_starter_dialog_shell_test.dart
@@ -1,0 +1,174 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:magic/magic.dart';
+import 'package:magic_starter/magic_starter.dart';
+import 'package:magic_starter/src/ui/widgets/magic_starter_dialog_shell.dart';
+
+void main() {
+  setUp(() async {
+    MagicApp.reset();
+    Magic.flush();
+    Magic.singleton('magic_starter', () => MagicStarterManager());
+    Magic.singleton('log', () => LogManager());
+    Config.set('logging', {
+      'default': 'console',
+      'channels': {
+        'console': {'driver': 'console', 'level': 'debug'},
+      },
+    });
+    Config.set('wind.colors.primary', 'indigo');
+  });
+
+  Widget wrap(Widget widget) {
+    final themeData = WindThemeData(
+      colors: {
+        'primary': Colors.indigo,
+      },
+    );
+    return WindTheme(
+      data: themeData,
+      child: MaterialApp(
+        theme: themeData.toThemeData(),
+        home: Scaffold(
+          body: SingleChildScrollView(
+            child: SizedBox(
+              width: 1200,
+              height: 800,
+              child: widget,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('renders title text when provided', (tester) async {
+    tester.view.physicalSize = const Size(1200, 800);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(wrap(
+      const MagicStarterDialogShell(
+        title: 'Test Title',
+        body: Text('body content'),
+      ),
+    ));
+
+    expect(find.text('Test Title'), findsOneWidget);
+  });
+
+  testWidgets('renders description text when provided', (tester) async {
+    tester.view.physicalSize = const Size(1200, 800);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(wrap(
+      const MagicStarterDialogShell(
+        title: 'Test Title',
+        description: 'Test description text',
+        body: Text('body content'),
+      ),
+    ));
+
+    expect(find.text('Test description text'), findsOneWidget);
+  });
+
+  testWidgets('renders body content widget', (tester) async {
+    tester.view.physicalSize = const Size(1200, 800);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(wrap(
+      const MagicStarterDialogShell(
+        body: Text('unique body content'),
+      ),
+    ));
+
+    expect(find.text('unique body content'), findsOneWidget);
+  });
+
+  testWidgets('renders footer widget when provided', (tester) async {
+    tester.view.physicalSize = const Size(1200, 800);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(wrap(
+      const MagicStarterDialogShell(
+        body: Text('body content'),
+        footer: Text('footer content'),
+      ),
+    ));
+
+    expect(find.text('footer content'), findsOneWidget);
+  });
+
+  testWidgets('footer section absent when footer is null', (tester) async {
+    tester.view.physicalSize = const Size(1200, 800);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(wrap(
+      const MagicStarterDialogShell(
+        body: Text('body content'),
+      ),
+    ));
+
+    // The footer placeholder key must not be present when footer is null.
+    expect(
+      find.byKey(const Key('magic_starter_dialog_shell_footer')),
+      findsNothing,
+    );
+  });
+
+  testWidgets(
+    'reads containerClassName from MagicStarter.manager.modalTheme',
+    (tester) async {
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      MagicStarter.manager.modalTheme = const MagicStarterModalTheme(
+        containerClassName: 'rounded-3xl bg-red-50',
+      );
+
+      await tester.pumpWidget(wrap(
+        const MagicStarterDialogShell(
+          body: Text('body content'),
+        ),
+      ));
+
+      // Widget must render without error when a custom containerClassName is set.
+      expect(find.byType(MagicStarterDialogShell), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'reads titleClassName from MagicStarter.manager.modalTheme',
+    (tester) async {
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      MagicStarter.manager.modalTheme = const MagicStarterModalTheme(
+        titleClassName: 'text-2xl font-black text-red-600',
+      );
+
+      await tester.pumpWidget(wrap(
+        const MagicStarterDialogShell(
+          title: 'Styled Title',
+          body: Text('body content'),
+        ),
+      ));
+
+      // Widget must render the title without error when a custom titleClassName is set.
+      expect(find.text('Styled Title'), findsOneWidget);
+    },
+  );
+}

--- a/test/ui/widgets/magic_starter_password_confirm_dialog_test.dart
+++ b/test/ui/widgets/magic_starter_password_confirm_dialog_test.dart
@@ -157,4 +157,58 @@ void main() {
 
     expect(result, isTrue);
   });
+
+  group('modal theme integration', () {
+    testWidgets('uses custom containerClassName from modal theme',
+        (WidgetTester tester) async {
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      MagicStarter.useModalTheme(
+        const MagicStarterModalTheme(
+          containerClassName: 'bg-custom-test-container rounded-3xl',
+        ),
+      );
+
+      await tester.pumpWidget(wrap(const MagicStarterPasswordConfirmDialog()));
+
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is WDiv &&
+              widget.className != null &&
+              widget.className!.contains('bg-custom-test-container'),
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('uses custom titleClassName from modal theme',
+        (WidgetTester tester) async {
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      MagicStarter.useModalTheme(
+        const MagicStarterModalTheme(
+          titleClassName: 'text-custom-title-class font-black',
+        ),
+      );
+
+      await tester.pumpWidget(wrap(const MagicStarterPasswordConfirmDialog()));
+
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is WText &&
+              widget.className != null &&
+              widget.className!.contains('text-custom-title-class'),
+        ),
+        findsOneWidget,
+      );
+    });
+  });
 }

--- a/test/ui/widgets/magic_starter_two_factor_modal_test.dart
+++ b/test/ui/widgets/magic_starter_two_factor_modal_test.dart
@@ -313,4 +313,30 @@ void main() {
       expect(dialogResult, isTrue);
     },
   );
+
+  // -------------------------------------------------------------------------
+  // Modal theme integration
+  // -------------------------------------------------------------------------
+  group('modal theme integration', () {
+    testWidgets('uses custom containerClassName from modal theme',
+        (WidgetTester tester) async {
+      MagicStarter.useModalTheme(
+        const MagicStarterModalTheme(
+          containerClassName: 'bg-custom-test-container rounded-3xl',
+        ),
+      );
+
+      await pumpModal(tester);
+
+      expect(
+        find.byWidgetPredicate(
+          (widget) =>
+              widget is WDiv &&
+              widget.className != null &&
+              widget.className!.contains('bg-custom-test-container'),
+        ),
+        findsOneWidget,
+      );
+    });
+  });
 }


### PR DESCRIPTION
## Summary

- Add `MagicStarterModalTheme` — 13 Wind UI className token fields for customizable dialog styling via `MagicStarter.useModalTheme()`
- Add `MagicStarterConfirmDialog` with `ConfirmDialogVariant` enum (primary/danger/warning) and internal `MagicStarterDialogShell` composition widget
- Extend `ViewRegistry` with `registerModal()`/`hasModal()`/`makeModal()` + 3 auto-registered default modals
- Refactor `PasswordConfirmDialog` and `TwoFactorModal` to read theme tokens at build time (no breaking changes)
- Replace Material `AlertDialog` in team settings with `MagicStarterConfirmDialog`
- 555 tests passing, 23 files changed (+1711, -76)

## Test plan

- [x] 555 tests pass (`flutter test --coverage`)
- [x] `flutter analyze --no-fatal-infos` — clean (1 pre-existing info)
- [x] `dart format --set-exit-if-changed .` — 0 changes
- [x] New widget tests: DialogShell (7), ConfirmDialog (11), theme integration (3), registry modals (7), facade modals (10), team settings view (3)
- [x] Existing modal tests unbroken — backward compatible
- [x] Code review agent: APPROVED
- [x] Verifier agent: APPROVED
- [x] Linter agent: CLEAN