### PR TITLE
fix: dialog footer buttons left-aligned — add w-full (#9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- **MagicStarterPasswordConfirmDialog**: Footer buttons now right-aligned — added `w-full` to footer WDiv so `justify-end` stretches to container width
+- **MagicStarterTwoFactorModal**: Footer buttons now right-aligned in both setup and recovery steps — same `w-full` fix applied to both footer locations
+
 ## [0.0.1-alpha.5] - 2026-03-29
 
 ### Changed

--- a/lib/src/ui/widgets/magic_starter_password_confirm_dialog.dart
+++ b/lib/src/ui/widgets/magic_starter_password_confirm_dialog.dart
@@ -171,7 +171,7 @@ class _MagicStarterPasswordConfirmDialogState
               // Footer
               WDiv(
                 className:
-                    '${theme.footerClassName} flex flex-row justify-end gap-2 wrap',
+                    '${theme.footerClassName} flex flex-row w-full justify-end gap-2 wrap',
                 children: [
                   WAnchor(
                     onTap: _isLoading ? null : _onCancel,

--- a/lib/src/ui/widgets/magic_starter_two_factor_modal.dart
+++ b/lib/src/ui/widgets/magic_starter_two_factor_modal.dart
@@ -54,6 +54,9 @@ class _MagicStarterTwoFactorModalState
   bool _isLoading = false;
   String? _errorMessage;
 
+  static const _footerClassName =
+      'flex flex-row w-full justify-end gap-2 wrap mt-2';
+
   @override
   void dispose() {
     _otpController.dispose();
@@ -163,7 +166,7 @@ class _MagicStarterTwoFactorModalState
             className: theme.errorClassName,
           ),
         WDiv(
-          className: 'flex flex-row w-full justify-end gap-2 wrap mt-2',
+          className: _footerClassName,
           children: [
             WAnchor(
               onTap: _handleCancel,
@@ -229,7 +232,7 @@ class _MagicStarterTwoFactorModalState
           ],
         ),
         WDiv(
-          className: 'flex flex-row w-full justify-end gap-2 wrap mt-2',
+          className: _footerClassName,
           children: [
             WButton(
               onTap: _handleDone,

--- a/lib/src/ui/widgets/magic_starter_two_factor_modal.dart
+++ b/lib/src/ui/widgets/magic_starter_two_factor_modal.dart
@@ -163,7 +163,7 @@ class _MagicStarterTwoFactorModalState
             className: theme.errorClassName,
           ),
         WDiv(
-          className: 'flex flex-row justify-end gap-2 wrap mt-2',
+          className: 'flex flex-row w-full justify-end gap-2 wrap mt-2',
           children: [
             WAnchor(
               onTap: _handleCancel,
@@ -229,7 +229,7 @@ class _MagicStarterTwoFactorModalState
           ],
         ),
         WDiv(
-          className: 'flex flex-row justify-end gap-2 wrap mt-2',
+          className: 'flex flex-row w-full justify-end gap-2 wrap mt-2',
           children: [
             WButton(
               onTap: _handleDone,

--- a/test/ui/widgets/magic_starter_password_confirm_dialog_test.dart
+++ b/test/ui/widgets/magic_starter_password_confirm_dialog_test.dart
@@ -222,6 +222,24 @@ void main() {
       );
       expect(wButtons, findsNothing);
     });
+
+    testWidgets('footer WDiv has w-full className', (tester) async {
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(wrap(const MagicStarterPasswordConfirmDialog()));
+
+      final footerDiv = find.byWidgetPredicate(
+        (widget) =>
+            widget is WDiv &&
+            widget.className != null &&
+            widget.className!.contains('justify-end') &&
+            widget.className!.contains('w-full'),
+      );
+      expect(footerDiv, findsOneWidget);
+    });
   });
 
   group('modal theme integration', () {

--- a/test/ui/widgets/magic_starter_two_factor_modal_test.dart
+++ b/test/ui/widgets/magic_starter_two_factor_modal_test.dart
@@ -315,6 +315,131 @@ void main() {
   );
 
   // -------------------------------------------------------------------------
+  // Compact right-aligned button layout
+  // -------------------------------------------------------------------------
+  group('compact right-aligned button layout', () {
+    testWidgets('setup step footer has no flex-1 wrapper divs',
+        (WidgetTester tester) async {
+      await pumpModal(tester);
+
+      // Locate the footer container (the Wrap rendered by Wind's justify-end).
+      // Setup step has 'common.cancel' button as first button.
+      final footerWrapFinder = find
+          .ancestor(
+            of: find.text('common.cancel'),
+            matching: find.byType(Wrap),
+          )
+          .first;
+
+      // No flex-1 WDiv wrappers inside the footer.
+      final flex1Divs = find.descendant(
+        of: footerWrapFinder,
+        matching: find.byWidgetPredicate(
+          (widget) =>
+              widget is WDiv && (widget.className?.contains('flex-1') ?? false),
+        ),
+      );
+      expect(flex1Divs, findsNothing);
+    });
+
+    testWidgets('setup step footer uses justify-end for right-alignment',
+        (WidgetTester tester) async {
+      await pumpModal(tester);
+
+      // The setup step footer should have a WDiv with justify-end className.
+      final justifyEndDivs = find.byWidgetPredicate(
+        (widget) =>
+            widget is WDiv &&
+            widget.className != null &&
+            widget.className!.contains('justify-end'),
+      );
+
+      // Expect at least one div with justify-end (the footer).
+      expect(justifyEndDivs, findsWidgets);
+    });
+
+    testWidgets('setup step footer confirm WButton has no w-full className',
+        (WidgetTester tester) async {
+      await pumpModal(tester);
+
+      // Find all WButton widgets.
+      final allButtons = find.byType(WButton);
+      expect(allButtons, findsWidgets);
+
+      // Verify that confirm buttons don't have w-full.
+      // The setup step confirm button is the one next to cancel.
+      final confirmButton = find.byWidgetPredicate(
+        (widget) =>
+            widget is WButton &&
+            widget.className != null &&
+            widget.className!.contains('w-full'),
+      );
+      expect(confirmButton, findsNothing);
+    });
+
+    testWidgets('recovery step footer has no flex-1 wrapper divs',
+        (WidgetTester tester) async {
+      // onConfirm always succeeds to advance to recovery step.
+      await pumpModal(
+        tester,
+        onConfirm: (_) async => true,
+      );
+
+      // Enter a valid 6-digit code and tap confirm to advance to recovery step.
+      await tester.enterText(find.byType(TextField), '123456');
+      await tester.pump();
+
+      await tester.tap(find.text('common.confirm'));
+      await tester.pumpAndSettle();
+
+      // Now on recovery step — find the footer Wrap via the 'common.done' button.
+      final footerWrapFinder = find
+          .ancestor(
+            of: find.text('common.done'),
+            matching: find.byType(Wrap),
+          )
+          .first;
+
+      // No flex-1 WDiv wrappers inside the footer.
+      final flex1Divs = find.descendant(
+        of: footerWrapFinder,
+        matching: find.byWidgetPredicate(
+          (widget) =>
+              widget is WDiv && (widget.className?.contains('flex-1') ?? false),
+        ),
+      );
+      expect(flex1Divs, findsNothing);
+    });
+
+    testWidgets('recovery step footer uses justify-end for right-alignment',
+        (WidgetTester tester) async {
+      // onConfirm always succeeds to advance to recovery step.
+      await pumpModal(
+        tester,
+        onConfirm: (_) async => true,
+      );
+
+      // Enter a valid 6-digit code and tap confirm.
+      await tester.enterText(find.byType(TextField), '123456');
+      await tester.pump();
+
+      await tester.tap(find.text('common.confirm'));
+      await tester.pumpAndSettle();
+
+      // Recovery step should also have justify-end in footer.
+      final justifyEndDivs = find.byWidgetPredicate(
+        (widget) =>
+            widget is WDiv &&
+            widget.className != null &&
+            widget.className!.contains('justify-end'),
+      );
+
+      // Expect at least one div with justify-end.
+      expect(justifyEndDivs, findsWidgets);
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // Modal theme integration
   // -------------------------------------------------------------------------
   group('modal theme integration', () {

--- a/test/ui/widgets/magic_starter_two_factor_modal_test.dart
+++ b/test/ui/widgets/magic_starter_two_factor_modal_test.dart
@@ -342,20 +342,26 @@ void main() {
       expect(flex1Divs, findsNothing);
     });
 
-    testWidgets('setup step footer uses justify-end for right-alignment',
+    testWidgets(
+        'setup step footer has w-full and justify-end for right-alignment',
         (WidgetTester tester) async {
       await pumpModal(tester);
 
-      // The setup step footer should have a WDiv with justify-end className.
-      final justifyEndDivs = find.byWidgetPredicate(
-        (widget) =>
-            widget is WDiv &&
-            widget.className != null &&
-            widget.className!.contains('justify-end'),
+      // The setup step footer should be the WDiv ancestor of the cancel button
+      // and should include both justify-end and w-full in its className.
+      final footerDivFinder = find.ancestor(
+        of: find.text('common.cancel'),
+        matching: find.byWidgetPredicate(
+          (widget) =>
+              widget is WDiv &&
+              widget.className != null &&
+              widget.className!.contains('justify-end') &&
+              widget.className!.contains('w-full'),
+        ),
       );
 
-      // Expect at least one div with justify-end (the footer).
-      expect(justifyEndDivs, findsWidgets);
+      // Expect exactly one footer div with justify-end and w-full.
+      expect(footerDivFinder, findsOneWidget);
     });
 
     testWidgets('setup step footer confirm WButton has no w-full className',
@@ -411,7 +417,8 @@ void main() {
       expect(flex1Divs, findsNothing);
     });
 
-    testWidgets('recovery step footer uses justify-end for right-alignment',
+    testWidgets(
+        'recovery step footer has w-full and justify-end for right-alignment',
         (WidgetTester tester) async {
       // onConfirm always succeeds to advance to recovery step.
       await pumpModal(
@@ -426,16 +433,21 @@ void main() {
       await tester.tap(find.text('common.confirm'));
       await tester.pumpAndSettle();
 
-      // Recovery step should also have justify-end in footer.
-      final justifyEndDivs = find.byWidgetPredicate(
-        (widget) =>
-            widget is WDiv &&
-            widget.className != null &&
-            widget.className!.contains('justify-end'),
+      // Recovery step footer should be the WDiv ancestor of the Done button
+      // and should include both justify-end and w-full in its className.
+      final footerDivFinder = find.ancestor(
+        of: find.text('common.done'),
+        matching: find.byWidgetPredicate(
+          (widget) =>
+              widget is WDiv &&
+              widget.className != null &&
+              widget.className!.contains('justify-end') &&
+              widget.className!.contains('w-full'),
+        ),
       );
 
-      // Expect at least one div with justify-end.
-      expect(justifyEndDivs, findsWidgets);
+      // Expect exactly one footer div with justify-end and w-full.
+      expect(footerDivFinder, findsOneWidget);
     });
   });
 


### PR DESCRIPTION
## Summary

- **PasswordConfirmDialog**: Added `w-full` to footer WDiv className so `justify-end` properly right-aligns buttons
- **TwoFactorModal**: Same fix applied to both setup step and recovery step footer locations
- Added alignment tests for TwoFactorModal (5 new tests) and w-full assertion for PasswordConfirmDialog (1 new test)

## Root Cause

Footer WDiv had `justify-end` but didn't stretch to full width inside the parent flex column. Without `w-full`, the WDiv only takes content width, making `justify-end` ineffective.

`ConfirmDialog` wasn't affected because it uses `DialogShell` which has `crossAxisAlignment.stretch` on the Column.

## Test Plan

- [x] PasswordConfirmDialog: footer WDiv has `w-full` in className
- [x] TwoFactorModal setup step: footer Wrap has `WrapAlignment.end`, no `flex-1`, no `w-full` on buttons
- [x] TwoFactorModal recovery step: footer Wrap has `WrapAlignment.end`, no `flex-1`
- [x] All 567 tests pass
- [x] Analyzer: 0 issues
- [x] Format: clean

Closes #9