### PR TITLE
fix: resolve DialogShell bottom overflow when body exceeds viewport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.0.1-alpha.10] - 2026-04-07
+
+### 🐛 Bug Fixes
+- **MagicStarterDialogShell**: Fixed bottom overflow when body content exceeds viewport — removed `flex flex-col` from outer WDiv that broke constraint propagation to inner Column; body now scrolls correctly with sticky header/footer (#21)
+
 ## [0.0.1-alpha.9] - 2026-04-04
 
 ### ✨ New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable changes to this project will be documented in this file.
 ### 🐛 Bug Fixes
 - **MagicStarterDialogShell**: Fixed bottom overflow when body content exceeds viewport — removed `flex flex-col` from outer WDiv that broke constraint propagation to inner Column; body now scrolls correctly with sticky header/footer (#21)
 
+### 🔧 Improvements
+- **Dependencies**: Bumped minimum `magic` to `^1.0.0-alpha.7` — updated all test setUp blocks to bind `AuthManager` in the IoC container, matching the new container-resolved `Auth` facade
+
 ## [0.0.1-alpha.9] - 2026-04-04
 
 ### ✨ New Features

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 Flutter starter kit for the Magic Framework. Pre-built Auth, Profile, Teams & Notifications — 13 opt-in features, every screen overridable via Wind UI.
 
-**Version:** 0.0.1-alpha.9 · **Dart:** >=3.6.0 · **Flutter:** >=3.27.0
+**Version:** 0.0.1-alpha.10 · **Dart:** >=3.6.0 · **Flutter:** >=3.27.0
 
 ## Commands
 

--- a/lib/src/ui/widgets/magic_starter_dialog_shell.dart
+++ b/lib/src/ui/widgets/magic_starter_dialog_shell.dart
@@ -63,8 +63,7 @@ class MagicStarterDialogShell extends StatelessWidget {
           maxHeight: safeHeight * 0.85,
         ),
         child: WDiv(
-          className:
-              '${theme.containerClassName} flex flex-col w-full overflow-hidden',
+          className: '${theme.containerClassName} w-full overflow-hidden',
           child: Column(
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.stretch,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  magic: ^1.0.0-alpha.3
+  magic: ^1.0.0-alpha.7
   magic_cli: ^0.0.1-alpha.3
   magic_notifications: ^0.0.1-alpha.1
   args: ^2.7.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: magic_starter
 description: Starter kit for Magic Framework. Auth, Profile, Teams, Notifications — 13 opt-in features with overridable views.
-version: 0.0.1-alpha.9
+version: 0.0.1-alpha.10
 homepage: https://magic.fluttersdk.com/starter
 documentation: https://magic.fluttersdk.com/packages/starter/getting-started/installation
 repository: https://github.com/fluttersdk/magic_starter

--- a/test/http/controllers/magic_starter_auth_controller_test.dart
+++ b/test/http/controllers/magic_starter_auth_controller_test.dart
@@ -209,6 +209,7 @@ void main() {
 
       // 4. Bind mock guard for Auth facade.
       mockGuard = MockGuard();
+      Magic.singleton('auth', () => AuthManager());
       Auth.manager.forgetGuards();
       Auth.manager.extend('mock', (_) => mockGuard);
       Config.set('auth.defaults.guard', 'mock');

--- a/test/http/controllers/magic_starter_guest_auth_controller_test.dart
+++ b/test/http/controllers/magic_starter_guest_auth_controller_test.dart
@@ -239,6 +239,7 @@ void main() {
 
       // 4. Bind mock guard for Auth facade.
       mockGuard = MockGuard();
+      Magic.singleton('auth', () => AuthManager());
       Auth.manager.forgetGuards();
       Auth.manager.extend('mock', (_) => mockGuard);
       Config.set('auth.defaults.guard', 'mock');

--- a/test/http/controllers/magic_starter_notification_controller_test.dart
+++ b/test/http/controllers/magic_starter_notification_controller_test.dart
@@ -203,6 +203,7 @@ void main() {
       });
 
       mockGuard = MockGuard();
+      Magic.singleton('auth', () => AuthManager());
       Auth.manager.forgetGuards();
       Auth.manager.extend('mock', (_) => mockGuard);
       Config.set('auth.defaults.guard', 'mock');

--- a/test/http/controllers/magic_starter_otp_controller_test.dart
+++ b/test/http/controllers/magic_starter_otp_controller_test.dart
@@ -200,6 +200,7 @@ void main() {
 
       // 4. Bind MockGuard for Auth facade.
       mockGuard = MockGuard();
+      Magic.singleton('auth', () => AuthManager());
       Auth.manager.forgetGuards();
       Auth.manager.extend('mock', (_) => mockGuard);
       Config.set('auth.defaults.guard', 'mock');

--- a/test/http/controllers/magic_starter_profile_controller_sessions_test.dart
+++ b/test/http/controllers/magic_starter_profile_controller_sessions_test.dart
@@ -40,6 +40,7 @@ void main() {
       Magic.singleton('log', () => LogManager());
 
       mockGuard = MockGuard();
+      Magic.singleton('auth', () => AuthManager());
       Auth.manager.forgetGuards();
       Auth.manager.extend('mock', (_) => mockGuard);
       Config.set('auth.defaults.guard', 'mock');

--- a/test/http/controllers/magic_starter_profile_controller_test.dart
+++ b/test/http/controllers/magic_starter_profile_controller_test.dart
@@ -230,6 +230,7 @@ void main() {
 
       // 3. Bind mock guard for Auth facade.
       mockGuard = MockGuard();
+      Magic.singleton('auth', () => AuthManager());
       Auth.manager.forgetGuards();
       Auth.manager.extend('mock', (_) => mockGuard);
       Config.set('auth.defaults.guard', 'mock');

--- a/test/http/controllers/magic_starter_profile_controller_two_factor_test.dart
+++ b/test/http/controllers/magic_starter_profile_controller_two_factor_test.dart
@@ -256,6 +256,7 @@ void main() {
       Magic.singleton('log', () => LogManager());
 
       mockGuard = MockGuard();
+      Magic.singleton('auth', () => AuthManager());
       Auth.manager.forgetGuards();
       Auth.manager.extend('mock', (_) => mockGuard);
       Config.set('auth.defaults.guard', 'mock');

--- a/test/http/controllers/magic_starter_team_controller_test.dart
+++ b/test/http/controllers/magic_starter_team_controller_test.dart
@@ -234,6 +234,7 @@ void main() {
 
       // 4. Bind mock guard for Auth facade.
       mockGuard = MockGuard();
+      Magic.singleton('auth', () => AuthManager());
       Auth.manager.forgetGuards();
       Auth.manager.extend('mock', (_) => mockGuard);
       Config.set('auth.defaults.guard', 'mock');

--- a/test/integration/cross_feature_smoke_test.dart
+++ b/test/integration/cross_feature_smoke_test.dart
@@ -30,6 +30,7 @@ void main() {
       Magic.singleton('log', () => LogManager());
 
       mockGuard = MockGuard();
+      Magic.singleton('auth', () => AuthManager());
       Auth.manager.forgetGuards();
       Auth.manager.extend('mock', (_) => mockGuard);
       Config.set('auth.defaults.guard', 'mock');

--- a/test/ui/layouts/magic_starter_app_layout_test.dart
+++ b/test/ui/layouts/magic_starter_app_layout_test.dart
@@ -208,6 +208,7 @@ void main() {
     );
 
     final mockGuard = MockGuard();
+    Magic.singleton('auth', () => AuthManager());
     Auth.manager.forgetGuards();
     Auth.manager.extend(
       'mock',

--- a/test/ui/views/profile/magic_starter_profile_settings_delete_account_test.dart
+++ b/test/ui/views/profile/magic_starter_profile_settings_delete_account_test.dart
@@ -219,6 +219,7 @@ void main() {
 
       // 3. Bind auth with mock guard.
       mockGuard = MockGuard();
+      Magic.singleton('auth', () => AuthManager());
       Auth.manager.forgetGuards();
       Auth.manager.extend('mock', (_) => mockGuard);
       Config.set('auth.defaults.guard', 'mock');

--- a/test/ui/views/profile/magic_starter_profile_settings_email_verification_test.dart
+++ b/test/ui/views/profile/magic_starter_profile_settings_email_verification_test.dart
@@ -230,6 +230,7 @@ void main() {
 
       // 3. Bind auth with mock guard.
       mockGuard = MockGuard();
+      Magic.singleton('auth', () => AuthManager());
       Auth.manager.forgetGuards();
       Auth.manager.extend('mock', (_) => mockGuard);
       Config.set('auth.defaults.guard', 'mock');

--- a/test/ui/views/profile/magic_starter_profile_settings_newsletter_test.dart
+++ b/test/ui/views/profile/magic_starter_profile_settings_newsletter_test.dart
@@ -233,6 +233,7 @@ void main() {
 
       // 3. Bind auth with mock guard.
       mockGuard = MockGuard();
+      Magic.singleton('auth', () => AuthManager());
       Auth.manager.forgetGuards();
       Auth.manager.extend('mock', (_) => mockGuard);
       Config.set('auth.defaults.guard', 'mock');

--- a/test/ui/views/profile/magic_starter_profile_settings_two_factor_test.dart
+++ b/test/ui/views/profile/magic_starter_profile_settings_two_factor_test.dart
@@ -244,6 +244,7 @@ void main() {
 
       // 3. Bind auth with mock guard.
       mockGuard = MockGuard();
+      Magic.singleton('auth', () => AuthManager());
       Auth.manager.forgetGuards();
       Auth.manager.extend('mock', (_) => mockGuard);
       Config.set('auth.defaults.guard', 'mock');

--- a/test/ui/views/profile/magic_starter_profile_settings_view_test.dart
+++ b/test/ui/views/profile/magic_starter_profile_settings_view_test.dart
@@ -178,6 +178,7 @@ void main() {
 
       // 3. Bind auth with mock guard.
       mockGuard = MockGuard();
+      Magic.singleton('auth', () => AuthManager());
       Auth.manager.forgetGuards();
       Auth.manager.extend('mock', (_) => mockGuard);
       Config.set('auth.defaults.guard', 'mock');

--- a/test/ui/widgets/magic_starter_dialog_shell_test.dart
+++ b/test/ui/widgets/magic_starter_dialog_shell_test.dart
@@ -250,6 +250,46 @@ void main() {
       expect(maxHeight, closeTo(613.7, 1.0));
     });
 
+    testWidgets('body scrolls without overflow when content exceeds viewport',
+        (tester) async {
+      tester.view.physicalSize = const Size(400, 600);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(wrap(
+        MagicStarterDialogShell(
+          title: 'Overflow Test',
+          body: Column(
+            children: List.generate(
+              20,
+              (i) => SizedBox(height: 60, child: Text('Item $i')),
+            ),
+          ),
+          footerBuilder: (_) => const Text('sticky footer'),
+        ),
+      ));
+
+      // No overflow error should occur.
+      expect(tester.takeException(), isNull);
+
+      // Footer must still be rendered (sticky).
+      expect(
+        find.byKey(const Key('magic_starter_dialog_shell_footer')),
+        findsOneWidget,
+      );
+
+      // ListView must be present for scrolling.
+      final shellFinder = find.byType(MagicStarterDialogShell);
+      expect(
+        find.descendant(
+          of: shellFinder,
+          matching: find.byType(ListView),
+        ),
+        findsOneWidget,
+      );
+    });
+
     testWidgets('safeHeight is smaller than raw screen height', (tester) async {
       tester.view.physicalSize = const Size(400, 600);
       tester.view.devicePixelRatio = 1.0;

--- a/test/ui/widgets/magic_starter_dialog_shell_test.dart
+++ b/test/ui/widgets/magic_starter_dialog_shell_test.dart
@@ -281,11 +281,30 @@ void main() {
 
       // ListView must be present for scrolling.
       final shellFinder = find.byType(MagicStarterDialogShell);
+      final listViewFinder = find.descendant(
+        of: shellFinder,
+        matching: find.byType(ListView),
+      );
+      expect(listViewFinder, findsOneWidget);
+
+      // The body content (20 × 60px = 1200px) exceeds viewport — verify
+      // the ListView is scrollable by dragging and checking offset changes.
+      final scrollableFinder = find.descendant(
+        of: listViewFinder,
+        matching: find.byType(Scrollable),
+      );
+      final scrollPosition =
+          tester.state<ScrollableState>(scrollableFinder).position;
+      expect(scrollPosition.pixels, equals(0.0));
+
+      await tester.drag(listViewFinder, const Offset(0, -300));
+      await tester.pumpAndSettle();
+
+      expect(scrollPosition.pixels, greaterThan(0));
+
+      // Footer remains visible after scroll.
       expect(
-        find.descendant(
-          of: shellFinder,
-          matching: find.byType(ListView),
-        ),
+        find.byKey(const Key('magic_starter_dialog_shell_footer')),
         findsOneWidget,
       );
     });

--- a/test/ui/widgets/magic_starter_user_profile_dropdown_test.dart
+++ b/test/ui/widgets/magic_starter_user_profile_dropdown_test.dart
@@ -80,6 +80,7 @@ void main() {
 
     // Mock Auth guard
     mockGuard = MockGuard();
+    Magic.singleton('auth', () => AuthManager());
     Auth.manager.forgetGuards();
     Auth.manager.extend('mock', (_) => mockGuard);
     Config.set('auth.defaults.guard', 'mock');


### PR DESCRIPTION
## Summary
- Remove `flex flex-col` from outer WDiv in `MagicStarterDialogShell` — the Wind UI Flex widget broke constraint propagation to the inner Column, causing bottom overflow instead of scrolling when body content exceeded `maxHeight`
- WDiv now acts as a plain styled container, letting Column receive constraints directly from ConstrainedBox → Flexible + ListView scrolls correctly

## Test plan
- [x] New test: `body scrolls without overflow when content exceeds viewport` — 20 items × 60px in 400×600 viewport
- [x] All 13 dialog shell tests pass
- [x] Full suite: 579 tests pass
- [x] `flutter analyze`: 0 issues

Closes #21