### PR TITLE
docs: add tag format warning to release command

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -90,6 +90,10 @@ Create a GitHub Release using `gh` CLI. This triggers the full pipeline:
 2. **Creates the git tag** (e.g. `0.0.2`)
 3. **Triggers `publish.yml`** — tag push starts the `validate` job (analyze + format + test), then `publish` job (publish to pub.dev via OIDC)
 
+> **⚠️ CRITICAL: Tag format is `{version}` — NO `v` prefix!**
+> The `publish.yml` workflow triggers on tags matching `[0-9]+.[0-9]+.[0-9]+*`.
+> A `v` prefix (e.g. `v0.0.2`) will NOT trigger the publish pipeline.
+
 Determine if the version is a prerelease:
 - Contains `alpha` or `beta` or `rc` → add `--prerelease` flag
 - Otherwise → stable release, no flag


### PR DESCRIPTION
## Summary
- Added critical warning to `.claude/commands/release.md` about tag format: NO `v` prefix
- `publish.yml` triggers on `[0-9]+.[0-9]+.[0-9]+*` — a `v`-prefixed tag silently skips the pipeline

## Context
During 0.0.1-alpha.10 release, the tag was initially created as `v0.0.1-alpha.10` which didn't trigger publish. Had to delete and recreate as `0.0.1-alpha.10`.