### PR TITLE
feat: add titleSuffix and inlineActions to MagicStarterPageHeader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### ✨ New Features
+- **MagicStarterPageHeader**: Added `titleSuffix` (Widget?) for inline widgets after title (e.g. status badges) and `inlineActions` (bool) to force single-row layout on all screen sizes (#24)
+
 ## [0.0.1-alpha.10] - 2026-04-07
 
 ### 🐛 Bug Fixes

--- a/doc/basics/views-and-layouts.md
+++ b/doc/basics/views-and-layouts.md
@@ -493,12 +493,26 @@ MagicStarterPageHeader(
 )
 ```
 
+Detail view with status badge and always-inline layout:
+
+```dart
+MagicStarterPageHeader(
+  title: 'Task Details',
+  leading: Icon(Icons.arrow_back),
+  titleSuffix: StatusBadge(status: 'done'),
+  inlineActions: true,
+  actions: [IconButton(icon: Icon(Icons.edit), onPressed: () {})],
+)
+```
+
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `title` | `String` | ✅ | Main heading text |
 | `subtitle` | `String?` | — | Secondary line below the title |
 | `leading` | `Widget?` | — | Widget placed before the title (e.g. back button) |
 | `actions` | `List<Widget>?` | — | Row of trailing action widgets (e.g. buttons) |
+| `titleSuffix` | `Widget?` | — | Optional widget rendered inline after the title (e.g. status badge). Stays on the same row as the title text. |
+| `inlineActions` | `bool` | — | When `true`, forces single-row layout on all screen sizes (no mobile stacking). Useful for detail views where actions must stay inline with the title. |
 
 ### MagicStarterCard
 

--- a/doc/basics/views-and-layouts.md
+++ b/doc/basics/views-and-layouts.md
@@ -501,7 +501,7 @@ MagicStarterPageHeader(
   leading: Icon(Icons.arrow_back),
   titleSuffix: StatusBadge(status: 'done'),
   inlineActions: true,
-  actions: [IconButton(icon: Icon(Icons.edit), onPressed: () {})],
+  actions: [WButton(onTap: () {}, child: WText('Edit'))],
 )
 ```
 

--- a/lib/src/ui/widgets/magic_starter_page_header.dart
+++ b/lib/src/ui/widgets/magic_starter_page_header.dart
@@ -63,7 +63,11 @@ class MagicStarterPageHeader extends StatelessWidget {
                   ),
               ],
             ),
-            if (titleSuffix != null) titleSuffix!,
+            if (titleSuffix != null)
+              WDiv(
+                className: 'flex-shrink-0',
+                child: titleSuffix!,
+              ),
           ],
         ),
         if (actions != null && actions!.isNotEmpty)

--- a/lib/src/ui/widgets/magic_starter_page_header.dart
+++ b/lib/src/ui/widgets/magic_starter_page_header.dart
@@ -18,20 +18,30 @@ class MagicStarterPageHeader extends StatelessWidget {
   /// Optional trailing action widgets.
   final List<Widget>? actions;
 
+  /// Optional widget rendered inline after the title column, inside the title+leading row.
+  final Widget? titleSuffix;
+
+  /// When true, the outer WDiv uses a single-row layout (`flex-row`) instead of
+  /// the default responsive `flex-col sm:flex-row` stacked layout.
+  final bool inlineActions;
+
   const MagicStarterPageHeader({
     super.key,
     required this.title,
     this.subtitle,
     this.leading,
     this.actions,
+    this.titleSuffix,
+    this.inlineActions = false,
   });
 
   @override
   Widget build(BuildContext context) {
     final leading = this.leading;
     return WDiv(
-      className:
-          'w-full flex flex-col sm:flex-row items-start sm:items-center sm:justify-between gap-4 p-2 lg:p-4 border-b border-gray-200 dark:border-gray-700',
+      className: inlineActions
+          ? 'w-full flex flex-row items-center justify-between gap-4 p-2 lg:p-4 border-b border-gray-200 dark:border-gray-700'
+          : 'w-full flex flex-col sm:flex-row items-start sm:items-center sm:justify-between gap-4 p-2 lg:p-4 border-b border-gray-200 dark:border-gray-700',
       children: [
         WDiv(
           className: 'flex flex-row items-center gap-3 sm:flex-1 min-w-0',
@@ -53,6 +63,7 @@ class MagicStarterPageHeader extends StatelessWidget {
                   ),
               ],
             ),
+            if (titleSuffix != null) titleSuffix!,
           ],
         ),
         if (actions != null && actions!.isNotEmpty)

--- a/lib/src/ui/widgets/magic_starter_page_header.dart
+++ b/lib/src/ui/widgets/magic_starter_page_header.dart
@@ -44,7 +44,9 @@ class MagicStarterPageHeader extends StatelessWidget {
           : 'w-full flex flex-col sm:flex-row items-start sm:items-center sm:justify-between gap-4 p-2 lg:p-4 border-b border-gray-200 dark:border-gray-700',
       children: [
         WDiv(
-          className: 'flex flex-row items-center gap-3 sm:flex-1 min-w-0',
+          className: inlineActions
+              ? 'flex flex-row items-center gap-3 flex-1 min-w-0'
+              : 'flex flex-row items-center gap-3 sm:flex-1 min-w-0',
           children: [
             if (leading != null) leading,
             WDiv(

--- a/test/ui/widgets/magic_starter_page_header_test.dart
+++ b/test/ui/widgets/magic_starter_page_header_test.dart
@@ -148,4 +148,99 @@ void main() {
     final outerDiv = tester.widget<WDiv>(find.byType(WDiv).first);
     expect(outerDiv.className, contains('sm:flex-row'));
   });
+
+  testWidgets('titleSuffix renders inline after title when provided',
+      (tester) async {
+    const suffixKey = Key('test_suffix');
+
+    await tester.pumpWidget(
+      wrap(
+        MagicStarterPageHeader(
+          title: 'My Page',
+          titleSuffix: Container(key: suffixKey),
+        ),
+      ),
+    );
+
+    expect(find.byKey(suffixKey), findsOneWidget);
+  });
+
+  testWidgets('titleSuffix not rendered when null', (tester) async {
+    const suffixKey = Key('test_suffix_null');
+
+    await tester.pumpWidget(
+      wrap(const MagicStarterPageHeader(title: 'My Page')),
+    );
+
+    expect(find.byKey(suffixKey), findsNothing);
+  });
+
+  testWidgets(
+      'inlineActions: true outer WDiv className contains flex-row without flex-col',
+      (tester) async {
+    await tester.pumpWidget(
+      wrap(
+        MagicStarterPageHeader(
+          title: 'Inline',
+          inlineActions: true,
+          actions: [
+            ElevatedButton(onPressed: () {}, child: const Text('Go')),
+          ],
+        ),
+      ),
+    );
+
+    final outerDiv = tester.widget<WDiv>(find.byType(WDiv).first);
+    expect(outerDiv.className, contains('flex-row'));
+    expect(outerDiv.className, isNot(contains('flex-col')));
+  });
+
+  testWidgets('inlineActions: false (default) retains flex-col sm:flex-row',
+      (tester) async {
+    await tester.pumpWidget(
+      wrap(
+        MagicStarterPageHeader(
+          title: 'Default Layout',
+          actions: [
+            ElevatedButton(onPressed: () {}, child: const Text('Go')),
+          ],
+        ),
+      ),
+    );
+
+    final outerDiv = tester.widget<WDiv>(find.byType(WDiv).first);
+    expect(outerDiv.className, contains('flex-col'));
+    expect(outerDiv.className, contains('sm:flex-row'));
+  });
+
+  testWidgets(
+      'combined titleSuffix + inlineActions: true + leading — all elements render',
+      (tester) async {
+    const leadingKey = Key('combined_leading');
+    const suffixKey = Key('combined_suffix');
+    const actionKey = Key('combined_action');
+
+    await tester.pumpWidget(
+      wrap(
+        MagicStarterPageHeader(
+          title: 'Combined',
+          leading: const Icon(Icons.arrow_back, key: leadingKey),
+          titleSuffix: const SizedBox(key: suffixKey, width: 8),
+          inlineActions: true,
+          actions: [
+            ElevatedButton(
+              key: actionKey,
+              onPressed: () {},
+              child: const Text('Act'),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    expect(find.byKey(leadingKey), findsOneWidget);
+    expect(find.byKey(suffixKey), findsOneWidget);
+    expect(find.byKey(actionKey), findsOneWidget);
+    expect(find.text('Combined'), findsOneWidget);
+  });
 }

--- a/test/ui/widgets/magic_starter_page_header_test.dart
+++ b/test/ui/widgets/magic_starter_page_header_test.dart
@@ -166,13 +166,21 @@ void main() {
   });
 
   testWidgets('titleSuffix not rendered when null', (tester) async {
-    const suffixKey = Key('test_suffix_null');
-
     await tester.pumpWidget(
       wrap(const MagicStarterPageHeader(title: 'My Page')),
     );
 
-    expect(find.byKey(suffixKey), findsNothing);
+    // When titleSuffix is null, the inner title row should contain only
+    // the title column WDiv — no extra children for the suffix wrapper.
+    final headerFinder = find.byType(MagicStarterPageHeader);
+    final innerDivs = find.descendant(
+      of: headerFinder,
+      matching: find.byType(WDiv),
+    );
+
+    // Outer WDiv + inner title row WDiv + title column WDiv = 3.
+    // No suffix wrapper WDiv should be present.
+    expect(innerDivs, findsNWidgets(3));
   });
 
   testWidgets(


### PR DESCRIPTION
## Summary
- **`titleSuffix`** (`Widget?`) — renders inline after the title column inside the title+leading row (e.g. status badges)
- **`inlineActions`** (`bool`, default `false`) — forces single-row layout on all screen sizes, no mobile stacking

## Test plan
- [x] 6 new tests: titleSuffix renders, titleSuffix null, inlineActions true, inlineActions false (default), combined all params
- [x] 8 existing tests unmodified and passing
- [x] Full suite: 584 tests pass
- [x] `flutter analyze`: 0 issues
- [x] CHANGELOG + doc/basics/views-and-layouts.md updated

Closes #24