### PR TITLE
feat: add sidebarFooterBuilder for customizable sidebar/drawer footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### ✨ New Features
+- **Sidebar Footer**: Added `sidebarFooterBuilder` slot via `MagicStarter.useSidebarFooter()` — renders custom widget between navigation and user menu in both desktop sidebar and mobile drawer (#27)
+
 ## [0.0.1-alpha.11] - 2026-04-07
 
 ### ✨ New Features

--- a/doc/basics/views-and-layouts.md
+++ b/doc/basics/views-and-layouts.md
@@ -223,6 +223,14 @@ MagicStarter.useNavigation(
   bottomItems: [...],
 );
 
+// Sidebar footer — custom widget between nav items and user menu
+MagicStarter.useSidebarFooter((context) {
+  return MyVersionBadge();
+});
+
+// Custom logo/brand — replaces default app name text
+// MagicStarter.useNavigationTheme(brandBuilder: ...) handles this
+
 // Custom navigation colors and brand
 MagicStarter.useNavigationTheme(
   MagicStarterNavigationTheme(

--- a/lib/src/facades/magic_starter.dart
+++ b/lib/src/facades/magic_starter.dart
@@ -143,6 +143,13 @@ class MagicStarter {
     manager.headerBuilder = builder;
   }
 
+  /// Register a custom sidebar footer builder. When set, rendered at the bottom of the sidebar.
+  static void useSidebarFooter(
+    Widget Function(BuildContext context) builder,
+  ) {
+    manager.sidebarFooterBuilder = builder;
+  }
+
   /// Register a custom social login buttons builder.
   ///
   /// When set, social login buttons appear on login and register pages

--- a/lib/src/facades/magic_starter.dart
+++ b/lib/src/facades/magic_starter.dart
@@ -143,7 +143,8 @@ class MagicStarter {
     manager.headerBuilder = builder;
   }
 
-  /// Register a custom sidebar footer builder. When set, rendered at the bottom of the sidebar.
+  /// Register a custom sidebar footer builder. When set, rendered between the
+  /// navigation and user menu in both the desktop sidebar and mobile drawer.
   static void useSidebarFooter(
     Widget Function(BuildContext context) builder,
   ) {

--- a/lib/src/magic_starter_manager.dart
+++ b/lib/src/magic_starter_manager.dart
@@ -311,6 +311,9 @@ class MagicStarterManager {
   /// Custom header builder. When set, replaces the default header.
   Widget Function(BuildContext context, bool isDesktop)? headerBuilder;
 
+  /// Custom sidebar footer builder. When set, rendered at the bottom of the sidebar.
+  Widget Function(BuildContext context)? sidebarFooterBuilder;
+
   /// Social login builder. When set, renders custom social login buttons.
   SocialLoginBuilder? socialLoginBuilder;
 
@@ -506,6 +509,7 @@ class MagicStarterManager {
     navigationConfig = null;
     onLogout = null;
     headerBuilder = null;
+    sidebarFooterBuilder = null;
     socialLoginBuilder = null;
     notificationTypeMapper = null;
     navigationTheme = const MagicStarterNavigationTheme();

--- a/lib/src/magic_starter_manager.dart
+++ b/lib/src/magic_starter_manager.dart
@@ -311,7 +311,8 @@ class MagicStarterManager {
   /// Custom header builder. When set, replaces the default header.
   Widget Function(BuildContext context, bool isDesktop)? headerBuilder;
 
-  /// Custom sidebar footer builder. When set, rendered at the bottom of the sidebar.
+  /// Custom sidebar footer builder. When set, rendered between the
+  /// navigation and user menu in both the desktop sidebar and mobile drawer.
   Widget Function(BuildContext context)? sidebarFooterBuilder;
 
   /// Social login builder. When set, renders custom social login buttons.

--- a/lib/src/ui/layouts/magic_starter_app_layout.dart
+++ b/lib/src/ui/layouts/magic_starter_app_layout.dart
@@ -160,6 +160,8 @@ class _MagicStarterAppLayoutState extends State<MagicStarterAppLayout> {
         _buildTeamSelector(context),
         const WSpacer(className: 'h-2'),
         Expanded(child: _buildNavigation(context, currentPath)),
+        if (MagicStarter.manager.sidebarFooterBuilder != null)
+          MagicStarter.manager.sidebarFooterBuilder!(context),
         _buildUserMenu(context),
       ],
     );
@@ -191,6 +193,8 @@ class _MagicStarterAppLayoutState extends State<MagicStarterAppLayout> {
                 onItemTap: () => Navigator.of(context).pop(),
               ),
             ),
+            if (MagicStarter.manager.sidebarFooterBuilder != null)
+              MagicStarter.manager.sidebarFooterBuilder!(context),
             _buildUserMenu(context),
           ],
         ),

--- a/test/facades/magic_starter_facade_test.dart
+++ b/test/facades/magic_starter_facade_test.dart
@@ -328,6 +328,24 @@ void main() {
       });
     });
 
+    group('sidebarFooter', () {
+      test('useSidebarFooter() sets manager.sidebarFooterBuilder', () {
+        MagicStarter.useSidebarFooter((context) => const SizedBox());
+
+        expect(MagicStarter.manager.sidebarFooterBuilder, isNotNull);
+      });
+
+      test('manager.reset() clears sidebarFooterBuilder', () {
+        MagicStarter.useSidebarFooter((context) => const SizedBox());
+
+        expect(MagicStarter.manager.sidebarFooterBuilder, isNotNull);
+
+        MagicStarter.manager.reset();
+
+        expect(MagicStarter.manager.sidebarFooterBuilder, isNull);
+      });
+    });
+
     group('modal registry defaults', () {
       test('default modal.confirm is registered after manager init', () {
         expect(MagicStarter.view.hasModal('modal.confirm'), isTrue);


### PR DESCRIPTION
## Summary
- Add `sidebarFooterBuilder` slot to `MagicStarterManager` for injecting custom widgets between navigation items and user menu in both desktop sidebar and mobile drawer
- Expose via `MagicStarter.useSidebarFooter()` facade method following existing `useHeader()` pattern
- Logo/brand customization already covered by existing `useNavigationTheme(brandBuilder: ...)`

Closes #27

## Test plan
- [x] `useSidebarFooter()` sets `manager.sidebarFooterBuilder` (facade test)
- [x] `manager.reset()` clears `sidebarFooterBuilder` back to null (facade test)
- [x] All 586 tests pass
- [x] Analyzer: 0 issues
- [x] Format: 0 changes