### PR TITLE
feat: move theme toggle from sidebar to user profile dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### ✨ New Features
 - **Sidebar Footer**: Added `sidebarFooterBuilder` slot via `MagicStarter.useSidebarFooter()` — renders custom widget between navigation and user menu in both desktop sidebar and mobile drawer (#27)
+- **MagicStarterUserProfileDropdown**: Moved theme toggle from sidebar bottom bar into user profile dropdown menu — sidebar now shows only avatar, name, and notification bell (#30)
 
 ### 🐛 Bug Fixes
 - **MagicStarterUserProfileDropdown**: Fixed menu overflow when many profile menu items are registered — wrapped menu items in scrollable `overflow-y-auto` WDiv, keeping header and logout footer fixed (#28)

--- a/lib/src/ui/layouts/magic_starter_app_layout.dart
+++ b/lib/src/ui/layouts/magic_starter_app_layout.dart
@@ -581,24 +581,6 @@ class _MagicStarterAppLayoutState extends State<MagicStarterAppLayout> {
           ),
           // Notification bell (gated by feature toggle)
           _buildNotificationBell(),
-          // Theme toggle (standalone)
-          WAnchor(
-            onTap: () => context.windTheme.toggleTheme(),
-            child: WDiv(
-              className: '''
-                w-8 h-8 rounded-lg flex-shrink-0
-                flex items-center justify-center
-                hover:bg-gray-100 dark:hover:bg-gray-800 duration-150
-              ''',
-              child: WIcon(
-                context.windIsDark
-                    ? Icons.light_mode_outlined
-                    : Icons.dark_mode_outlined,
-                semanticLabel: trans('common.toggle_theme'),
-                className: 'text-[18px] text-gray-400 dark:text-gray-500',
-              ),
-            ),
-          ),
         ],
       ),
     );

--- a/lib/src/ui/widgets/magic_starter_user_profile_dropdown.dart
+++ b/lib/src/ui/widgets/magic_starter_user_profile_dropdown.dart
@@ -213,62 +213,16 @@ class MagicStarterUserProfileDropdown extends StatelessWidget {
                             ''',
             ),
           ),
-          WText(
-            label,
-            states: {if (isDanger) 'danger'},
-            className: '''
-                            text-sm font-medium
-                            text-gray-900 dark:text-gray-100
-                            danger:text-red-600 dark:danger:text-red-500
-                        ''',
-          ),
-        ],
-      ),
-    );
-  }
-
-  /// Builds the theme toggle row.
-  ///
-  /// Tapping toggles between light and dark mode without closing the dropdown.
-  Widget _buildThemeToggle(BuildContext context) {
-    final isDark = context.windIsDark;
-
-    return WAnchor(
-      onTap: () => context.windTheme.toggleTheme(),
-      child: WDiv(
-        className: '''
-          mx-2 px-3 py-2.5 w-full
-          rounded-lg
-          hover:bg-gray-50 dark:hover:bg-gray-700/50
-          active:bg-gray-100 dark:active:bg-gray-700
-          flex items-center gap-3
-          cursor-pointer
-          transition-colors duration-150
-        ''',
-        children: [
-          WDiv(
-            className: '''
-              w-8 h-8
-              rounded-lg
-              bg-gray-100 dark:bg-gray-700
-              hover:bg-gray-200 dark:hover:bg-gray-600
-              flex items-center justify-center
-              transition-colors duration-150
-            ''',
-            child: WIcon(
-              isDark ? Icons.light_mode_outlined : Icons.dark_mode_outlined,
-              className: 'text-lg text-gray-600 dark:text-gray-400',
-            ),
-          ),
           WDiv(
             className: 'flex-1 min-w-0',
             child: WText(
-              trans('common.toggle_theme'),
+              label,
+              states: {if (isDanger) 'danger'},
               className: '''
-                text-sm font-medium
-                text-gray-900 dark:text-gray-100
-                truncate
-              ''',
+                              text-sm font-medium truncate
+                              text-gray-900 dark:text-gray-100
+                              danger:text-red-600 dark:danger:text-red-500
+                          ''',
             ),
           ),
         ],

--- a/lib/src/ui/widgets/magic_starter_user_profile_dropdown.dart
+++ b/lib/src/ui/widgets/magic_starter_user_profile_dropdown.dart
@@ -145,6 +145,14 @@ class MagicStarterUserProfileDropdown extends StatelessWidget {
                       MagicStarterConfig.notificationPreferencesRoute());
                 },
               ),
+            // Theme toggle — does not close dropdown on tap.
+            _buildMenuItem(
+              icon: context.windIsDark
+                  ? Icons.light_mode_outlined
+                  : Icons.dark_mode_outlined,
+              label: trans('common.toggle_theme'),
+              onTap: () => context.windTheme.toggleTheme(),
+            ),
           ],
         ),
         // Fixed footer — divider + logout.
@@ -213,6 +221,55 @@ class MagicStarterUserProfileDropdown extends StatelessWidget {
                             text-gray-900 dark:text-gray-100
                             danger:text-red-600 dark:danger:text-red-500
                         ''',
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// Builds the theme toggle row.
+  ///
+  /// Tapping toggles between light and dark mode without closing the dropdown.
+  Widget _buildThemeToggle(BuildContext context) {
+    final isDark = context.windIsDark;
+
+    return WAnchor(
+      onTap: () => context.windTheme.toggleTheme(),
+      child: WDiv(
+        className: '''
+          mx-2 px-3 py-2.5 w-full
+          rounded-lg
+          hover:bg-gray-50 dark:hover:bg-gray-700/50
+          active:bg-gray-100 dark:active:bg-gray-700
+          flex items-center gap-3
+          cursor-pointer
+          transition-colors duration-150
+        ''',
+        children: [
+          WDiv(
+            className: '''
+              w-8 h-8
+              rounded-lg
+              bg-gray-100 dark:bg-gray-700
+              hover:bg-gray-200 dark:hover:bg-gray-600
+              flex items-center justify-center
+              transition-colors duration-150
+            ''',
+            child: WIcon(
+              isDark ? Icons.light_mode_outlined : Icons.dark_mode_outlined,
+              className: 'text-lg text-gray-600 dark:text-gray-400',
+            ),
+          ),
+          WDiv(
+            className: 'flex-1 min-w-0',
+            child: WText(
+              trans('common.toggle_theme'),
+              className: '''
+                text-sm font-medium
+                text-gray-900 dark:text-gray-100
+                truncate
+              ''',
+            ),
           ),
         ],
       ),

--- a/test/ui/widgets/magic_starter_user_profile_dropdown_test.dart
+++ b/test/ui/widgets/magic_starter_user_profile_dropdown_test.dart
@@ -271,4 +271,19 @@ void main() {
 
     expect(find.text('Custom Trigger'), findsOneWidget);
   });
+
+  testWidgets('shows theme toggle in dropdown menu', (tester) async {
+    await tester.pumpWidget(wrap(const MagicStarterUserProfileDropdown()));
+    await tester.pumpAndSettle();
+
+    // Open dropdown
+    await tester.tap(find.text('C'));
+    await tester.pumpAndSettle();
+
+    // Theme toggle label should be visible
+    expect(find.text('common.toggle_theme'), findsOneWidget);
+
+    // Theme toggle icon should be visible (dark_mode when in light mode)
+    expect(find.byIcon(Icons.dark_mode_outlined), findsOneWidget);
+  });
 }

--- a/test/ui/widgets/magic_starter_user_profile_dropdown_test.dart
+++ b/test/ui/widgets/magic_starter_user_profile_dropdown_test.dart
@@ -272,7 +272,8 @@ void main() {
     expect(find.text('Custom Trigger'), findsOneWidget);
   });
 
-  testWidgets('shows theme toggle in dropdown menu', (tester) async {
+  testWidgets('shows theme toggle in dropdown and toggles without closing',
+      (tester) async {
     await tester.pumpWidget(wrap(const MagicStarterUserProfileDropdown()));
     await tester.pumpAndSettle();
 
@@ -280,10 +281,20 @@ void main() {
     await tester.tap(find.text('C'));
     await tester.pumpAndSettle();
 
-    // Theme toggle label should be visible
+    // Theme toggle label and icon visible (dark_mode icon in light mode)
     expect(find.text('common.toggle_theme'), findsOneWidget);
-
-    // Theme toggle icon should be visible (dark_mode when in light mode)
     expect(find.byIcon(Icons.dark_mode_outlined), findsOneWidget);
+    expect(find.byIcon(Icons.light_mode_outlined), findsNothing);
+
+    // Tap theme toggle — should switch icon and keep dropdown open.
+    await tester.tap(find.text('common.toggle_theme'));
+    await tester.pumpAndSettle();
+
+    // Icon should have toggled to light_mode (now in dark mode).
+    expect(find.byIcon(Icons.light_mode_outlined), findsOneWidget);
+    expect(find.byIcon(Icons.dark_mode_outlined), findsNothing);
+
+    // Dropdown should still be open — toggle label still visible.
+    expect(find.text('common.toggle_theme'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- Removed theme toggle button from sidebar bottom bar (was next to notification bell)
- Added theme toggle as a menu item inside user profile dropdown — tapping toggles light/dark without closing the dropdown
- Sidebar bottom bar now cleaner: avatar + name + notification bell only

Closes #30

## Test plan
- [x] New test: `shows theme toggle in dropdown menu` — verifies toggle label and icon visible
- [x] All dropdown tests pass (10 total)
- [x] Full suite: 585 tests pass
- [x] Analyzer: 0 issues
- [x] Format: 0 changes