### PR TITLE
docs: update docs for sidebar footer, theme toggle, and dropdown changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,20 @@ MagicStarter.view.register('layout.guest', (context, {required child}) {
 
 All views are resolved through `MagicStarter.view.make('auth.login')` — the registry always wins over defaults.
 
+### Layout Customization
+
+```dart
+// Custom header — replaces the default mobile header
+MagicStarter.useHeader((context, isDesktop) {
+  return MyCustomHeader(showMenuButton: !isDesktop);
+});
+
+// Sidebar footer — custom widget between nav items and user menu
+MagicStarter.useSidebarFooter((context) {
+  return MyVersionBadge();
+});
+```
+
 ---
 
 ## Reusable Widgets
@@ -265,7 +279,7 @@ final success = await MagicStarterTwoFactorModal.show(
 | `MagicStarterAuthFormCard` | Centered card wrapper for auth-adjacent screens (invite accept, onboarding) |
 | `MagicStarterTimezoneSelect` | Searchable timezone dropdown backed by `GET /timezones` |
 | `MagicStarterTeamSelector` | Current-team switcher dropdown with create/settings links |
-| `MagicStarterUserProfileDropdown` | User avatar menu with profile links and logout |
+| `MagicStarterUserProfileDropdown` | User avatar menu with profile links, theme toggle, and logout |
 | `MagicStarterNotificationDropdown` | Bell-icon dropdown with live unread badge and mark-as-read |
 | `MagicStarterSocialDivider` | "Or continue with" divider for auth forms |
 

--- a/doc/architecture/manager.md
+++ b/doc/architecture/manager.md
@@ -7,6 +7,7 @@
 - [Navigation Configuration](#navigation-configuration)
 - [Navigation Theme](#navigation-theme)
 - [Modal Theme](#modal-theme)
+- [Sidebar Footer Builder](#sidebar-footer-builder)
 - [Header Builder](#header-builder)
 - [Logout Callback](#logout-callback)
 - [Notification Type Mapper](#notification-type-mapper)
@@ -216,6 +217,21 @@ The theme is stored on `MagicStarterManager` as `modalTheme` and reset to defaul
 > [!TIP]
 > Register your modal theme in `AppServiceProvider.boot()` alongside `useNavigationTheme()`. Both follow the same pattern — register once, all widgets read the tokens at build time.
 
+<a name="sidebar-footer-builder"></a>
+## Sidebar Footer Builder
+
+Add a custom widget between the navigation items and the user menu in both the desktop sidebar and mobile drawer:
+
+```dart
+MagicStarter.useSidebarFooter((context) {
+  return MyVersionBadge();
+});
+```
+
+The builder receives the current `BuildContext` and should return any widget — a version badge, environment indicator, support link, etc.
+
+When `sidebarFooterBuilder` is `null` (the default), no extra content is rendered between navigation and the user menu.
+
 <a name="header-builder"></a>
 ## Header Builder
 
@@ -337,6 +353,7 @@ Default layouts:
 | `MagicStarter.useNavigation(...)` | `manager.navigationConfig = config` |
 | `MagicStarter.useNavigationTheme(theme)` | `manager.navigationTheme = theme` |
 | `MagicStarter.useModalTheme(theme)` | `manager.modalTheme = theme` |
+| `MagicStarter.useSidebarFooter(builder)` | `manager.sidebarFooterBuilder = builder` |
 | `MagicStarter.useHeader(builder)` | `manager.headerBuilder = builder` |
 | `MagicStarter.useLogout(callback)` | `manager.onLogout = callback` |
 | `MagicStarter.useSocialLogin(builder)` | `manager.socialLoginBuilder = builder` |

--- a/doc/basics/views-and-layouts.md
+++ b/doc/basics/views-and-layouts.md
@@ -328,7 +328,7 @@ Common pairings used throughout Magic Starter:
 | `hover:bg-gray-100` | `dark:hover:bg-gray-800` |
 
 > [!TIP]
-> Theme toggling is available in the app layout sidebar via `context.windTheme.toggleTheme()`. Check the current mode with `context.windIsDark`.
+> Theme toggling is available in the user profile dropdown menu via `context.windTheme.toggleTheme()`. Check the current mode with `context.windIsDark`.
 
 <a name="view-registry"></a>
 ## View Registry
@@ -654,7 +654,7 @@ The modal can also be used for standalone re-authentication (e.g. before a sensi
 | `MagicStarterAuthFormCard` | Centered card wrapper (max 480 px) for auth-adjacent screens — invite accept, onboarding, etc. Accepts `title`, `subtitle`, optional `errorMessage`, and a theme-toggle button. |
 | `MagicStarterTimezoneSelect` | Searchable timezone dropdown backed by `GET /timezones?search=...`. Debounces search at 300 ms and always includes the pre-selected value in options. |
 | `MagicStarterTeamSelector` | Current-team switcher dropdown. Requires `MagicStarter.teamResolver` to be registered. `compact` mode hides the team name label. |
-| `MagicStarterUserProfileDropdown` | Circular avatar menu showing signed-in user info, profile links, and logout. Supports a custom `triggerBuilder`. |
+| `MagicStarterUserProfileDropdown` | Circular avatar menu showing signed-in user info, profile links, theme toggle, and logout. Supports a custom `triggerBuilder`. |
 | `MagicStarterNotificationDropdown` | Bell-icon dropdown backed by a `Stream<List<DatabaseNotification>>`. Displays live unread badge, color-coded icons, and mark-as-read callbacks. |
 | `MagicStarterSocialDivider` | Horizontal "Or continue with" divider for auth forms. No parameters — pure presentation. |
 | `MagicStarterHideBottomNav` | `InheritedWidget` that signals `MagicStarterAppLayout` to hide the mobile bottom navigation bar. Wrap a route layout with this widget and check `MagicStarterHideBottomNav.of(context)` in the layout's build method. |


### PR DESCRIPTION
## Summary
- Add `useSidebarFooter()` section and facade entry to manager doc
- Update theme toggle location from sidebar to user profile dropdown in views-and-layouts doc
- Add theme toggle mention to `MagicStarterUserProfileDropdown` widget descriptions
- Add layout customization section to README with `useHeader()`/`useSidebarFooter()`

## Test plan
- [ ] Docs-only change, no code modified