### PR TITLE
fix: extract icon constants for Flutter web tree-shaking compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### 🐛 Bug Fixes
+- **Icon Tree-Shaking**: Extracted all runtime-conditional `Icons.*` references into `static const` fields for Flutter web tree-shaking compatibility — fixes 11+ broken icon usages across 10 files (#37)
+
 ## [0.0.1-alpha.12] - 2026-04-09
 
 ### ✨ New Features

--- a/lib/src/ui/views/auth/magic_starter_login_view.dart
+++ b/lib/src/ui/views/auth/magic_starter_login_view.dart
@@ -23,6 +23,9 @@ class MagicStarterLoginView
 
 class _MagicStarterLoginViewState extends MagicStatefulViewState<
     MagicStarterAuthController, MagicStarterLoginView> {
+  static const _iconVisible = Icons.visibility;
+  static const _iconHidden = Icons.visibility_off;
+
   /// Both email and phone fields are always declared — the controller decides
   /// which one to include in the payload based on identity mode.
   late final form = MagicFormData(
@@ -93,7 +96,7 @@ class _MagicStarterLoginViewState extends MagicStatefulViewState<
                 onTap: () =>
                     setState(() => _obscurePassword = !_obscurePassword),
                 child: WIcon(
-                  _obscurePassword ? Icons.visibility : Icons.visibility_off,
+                  _obscurePassword ? _iconVisible : _iconHidden,
                   className: 'text-gray-400 text-xl',
                 ),
               ),

--- a/lib/src/ui/views/auth/magic_starter_register_view.dart
+++ b/lib/src/ui/views/auth/magic_starter_register_view.dart
@@ -23,6 +23,9 @@ class MagicStarterRegisterView
 
 class _MagicStarterRegisterViewState extends MagicStatefulViewState<
     MagicStarterAuthController, MagicStarterRegisterView> {
+  static const _iconVisible = Icons.visibility;
+  static const _iconHidden = Icons.visibility_off;
+
   /// Both email and phone fields are always declared — the controller decides
   /// which one to include in the payload based on identity mode.
   late final form = MagicFormData(
@@ -113,7 +116,7 @@ class _MagicStarterRegisterViewState extends MagicStatefulViewState<
                 onTap: () =>
                     setState(() => _obscurePassword = !_obscurePassword),
                 child: WIcon(
-                  _obscurePassword ? Icons.visibility : Icons.visibility_off,
+                  _obscurePassword ? _iconVisible : _iconHidden,
                   className: 'text-gray-400 text-xl',
                 ),
               ),
@@ -136,9 +139,7 @@ class _MagicStarterRegisterViewState extends MagicStatefulViewState<
                 onTap: () => setState(
                     () => _obscureConfirmation = !_obscureConfirmation),
                 child: WIcon(
-                  _obscureConfirmation
-                      ? Icons.visibility
-                      : Icons.visibility_off,
+                  _obscureConfirmation ? _iconVisible : _iconHidden,
                   className: 'text-gray-400 text-xl',
                 ),
               ),

--- a/lib/src/ui/views/auth/magic_starter_reset_password_view.dart
+++ b/lib/src/ui/views/auth/magic_starter_reset_password_view.dart
@@ -28,6 +28,9 @@ class _MagicStarterResetPasswordViewState extends MagicStatefulViewState<
   bool _obscurePassword = true;
   bool _obscureConfirmation = true;
 
+  static const _iconVisible = Icons.visibility;
+  static const _iconHidden = Icons.visibility_off;
+
   @override
   void onInit() {
     final email = MagicRouter.instance.queryParameter('email');
@@ -131,7 +134,7 @@ class _MagicStarterResetPasswordViewState extends MagicStatefulViewState<
                 onTap: () =>
                     setState(() => _obscurePassword = !_obscurePassword),
                 child: WIcon(
-                  _obscurePassword ? Icons.visibility : Icons.visibility_off,
+                  _obscurePassword ? _iconVisible : _iconHidden,
                   className: 'text-gray-400 text-xl',
                 ),
               ),
@@ -154,9 +157,7 @@ class _MagicStarterResetPasswordViewState extends MagicStatefulViewState<
                 onTap: () => setState(
                     () => _obscureConfirmation = !_obscureConfirmation),
                 child: WIcon(
-                  _obscureConfirmation
-                      ? Icons.visibility
-                      : Icons.visibility_off,
+                  _obscureConfirmation ? _iconVisible : _iconHidden,
                   className: 'text-gray-400 text-xl',
                 ),
               ),

--- a/lib/src/ui/views/notifications/magic_starter_notification_preferences_view.dart
+++ b/lib/src/ui/views/notifications/magic_starter_notification_preferences_view.dart
@@ -20,6 +20,14 @@ class MagicStarterNotificationPreferencesView
 class _MagicStarterNotificationPreferencesViewState
     extends MagicStatefulViewState<MagicStarterNotificationController,
         MagicStarterNotificationPreferencesView> {
+  static const _iconLocked = Icons.lock_outline;
+  static const _channelIcons = <String, IconData>{
+    'mail': Icons.mail_outline,
+    'database': Icons.inbox_outlined,
+    'push': Icons.notifications_outlined,
+  };
+  static const _defaultChannelIcon = Icons.circle_notifications_outlined;
+
   @override
   void onInit() {
     super.onInit();
@@ -137,7 +145,7 @@ class _MagicStarterNotificationPreferencesViewState
                 ${isEnabled && !isLocked ? 'bg-primary/10 dark:bg-primary/10' : 'bg-gray-100 dark:bg-gray-700'}
               ''',
               child: WIcon(
-                isLocked ? Icons.lock_outline : icon,
+                isLocked ? _iconLocked : icon,
                 className: '''
                   text-[18px]
                   ${isEnabled && !isLocked ? 'text-primary' : 'text-gray-500 dark:text-gray-400'}
@@ -170,12 +178,7 @@ class _MagicStarterNotificationPreferencesViewState
 
   /// Returns the appropriate icon for a notification channel.
   IconData _channelIcon(String channel) {
-    return switch (channel.toLowerCase()) {
-      'mail' => Icons.mail_outline,
-      'database' => Icons.inbox_outlined,
-      'push' => Icons.notifications_outlined,
-      _ => Icons.circle_notifications_outlined,
-    };
+    return _channelIcons[channel.toLowerCase()] ?? _defaultChannelIcon;
   }
 
   /// Returns a user-friendly label for a notification channel.

--- a/lib/src/ui/views/notifications/magic_starter_notifications_list_view.dart
+++ b/lib/src/ui/views/notifications/magic_starter_notifications_list_view.dart
@@ -33,6 +33,13 @@ class MagicStarterNotificationsListView extends StatefulWidget {
 
 class _MagicStarterNotificationsListViewState
     extends State<MagicStarterNotificationsListView> {
+  static const _notificationTypeIcons = <String, IconData>{
+    'monitor_up': Icons.check_circle_outline,
+    'monitor_degraded': Icons.warning_outlined,
+    'monitor_down': Icons.error_outline,
+  };
+  static const _defaultNotificationIcon = Icons.info_outline;
+
   PaginatedNotifications? _paginatedData;
   bool _isLoading = true;
   bool _hasError = false;
@@ -199,12 +206,8 @@ class _MagicStarterNotificationsListViewState
     final mapping = mapper?.call(notification.type);
 
     final IconData icon = mapping?.icon ??
-        switch (notification.type) {
-          'monitor_up' => Icons.check_circle_outline,
-          'monitor_degraded' => Icons.warning_outlined,
-          'monitor_down' => Icons.error_outline,
-          _ => Icons.info_outline,
-        };
+        _notificationTypeIcons[notification.type] ??
+        _defaultNotificationIcon;
 
     final String iconColor = mapping?.colorClass ??
         switch (notification.type) {

--- a/lib/src/ui/views/profile/magic_starter_profile_settings_view.dart
+++ b/lib/src/ui/views/profile/magic_starter_profile_settings_view.dart
@@ -33,6 +33,11 @@ class MagicStarterProfileSettingsView
 
 class _MagicStarterProfileSettingsViewState extends MagicStatefulViewState<
     MagicStarterProfileController, MagicStarterProfileSettingsView> {
+  static const _iconVisible = Icons.visibility;
+  static const _iconHidden = Icons.visibility_off;
+  static const _iconDesktop = Icons.computer;
+  static const _iconMobile = Icons.phone_android;
+
   // -- Profile & password forms -----------------------------------------------
 
   late final profileForm = MagicFormData(
@@ -634,7 +639,7 @@ class _MagicStarterProfileSettingsViewState extends MagicStatefulViewState<
               suffix: WAnchor(
                 onTap: () => setState(() => _obscureCurrent = !_obscureCurrent),
                 child: WIcon(
-                  _obscureCurrent ? Icons.visibility : Icons.visibility_off,
+                  _obscureCurrent ? _iconVisible : _iconHidden,
                   className: 'text-gray-400 text-xl',
                 ),
               ),
@@ -651,7 +656,7 @@ class _MagicStarterProfileSettingsViewState extends MagicStatefulViewState<
               suffix: WAnchor(
                 onTap: () => setState(() => _obscureNew = !_obscureNew),
                 child: WIcon(
-                  _obscureNew ? Icons.visibility : Icons.visibility_off,
+                  _obscureNew ? _iconVisible : _iconHidden,
                   className: 'text-gray-400 text-xl',
                 ),
               ),
@@ -669,9 +674,7 @@ class _MagicStarterProfileSettingsViewState extends MagicStatefulViewState<
                 onTap: () => setState(
                     () => _obscureConfirmation = !_obscureConfirmation),
                 child: WIcon(
-                  _obscureConfirmation
-                      ? Icons.visibility
-                      : Icons.visibility_off,
+                  _obscureConfirmation ? _iconVisible : _iconHidden,
                   className: 'text-gray-400 text-xl',
                 ),
               ),
@@ -1113,7 +1116,7 @@ class _MagicStarterProfileSettingsViewState extends MagicStatefulViewState<
           'flex flex-row items-start gap-3 p-3 rounded-lg bg-gray-50 dark:bg-gray-800/50 border border-gray-200 dark:border-gray-700',
       children: [
         WIcon(
-          isDesktop ? Icons.computer : Icons.phone_android,
+          isDesktop ? _iconDesktop : _iconMobile,
           className: 'text-gray-500 dark:text-gray-400 mt-1 text-xl',
         ),
         WDiv(
@@ -1313,9 +1316,7 @@ class _MagicStarterProfileSettingsViewState extends MagicStatefulViewState<
                 onTap: () => setState(
                     () => _obscureUpgradePassword = !_obscureUpgradePassword),
                 child: WIcon(
-                  _obscureUpgradePassword
-                      ? Icons.visibility
-                      : Icons.visibility_off,
+                  _obscureUpgradePassword ? _iconVisible : _iconHidden,
                   className: 'text-gray-400 text-xl',
                 ),
               ),
@@ -1335,9 +1336,7 @@ class _MagicStarterProfileSettingsViewState extends MagicStatefulViewState<
                 onTap: () => setState(() =>
                     _obscureUpgradeConfirmation = !_obscureUpgradeConfirmation),
                 child: WIcon(
-                  _obscureUpgradeConfirmation
-                      ? Icons.visibility
-                      : Icons.visibility_off,
+                  _obscureUpgradeConfirmation ? _iconVisible : _iconHidden,
                   className: 'text-gray-400 text-xl',
                 ),
               ),

--- a/lib/src/ui/widgets/magic_starter_notification_dropdown.dart
+++ b/lib/src/ui/widgets/magic_starter_notification_dropdown.dart
@@ -18,6 +18,13 @@ import 'package:magic_notifications/magic_notifications.dart';
 /// )
 /// ```
 class MagicStarterNotificationDropdown extends StatelessWidget {
+  static const _typeIcons = <String, IconData>{
+    'monitor_down': Icons.error_outline,
+    'monitor_up': Icons.check_circle_outline,
+    'monitor_degraded': Icons.warning_amber_outlined,
+  };
+  static const _defaultTypeIcon = Icons.notifications_none_outlined;
+
   /// Stream of notifications to display.
   final Stream<List<DatabaseNotification>> notificationStream;
 
@@ -338,16 +345,7 @@ class MagicStarterNotificationDropdown extends StatelessWidget {
   }
 
   IconData _getIconForType(String type) {
-    switch (type) {
-      case 'monitor_down':
-        return Icons.error_outline;
-      case 'monitor_up':
-        return Icons.check_circle_outline;
-      case 'monitor_degraded':
-        return Icons.warning_amber_outlined;
-      default:
-        return Icons.notifications_none_outlined;
-    }
+    return _typeIcons[type] ?? _defaultTypeIcon;
   }
 
   String _getColorForType(String type) {

--- a/lib/src/ui/widgets/magic_starter_password_confirm_dialog.dart
+++ b/lib/src/ui/widgets/magic_starter_password_confirm_dialog.dart
@@ -73,6 +73,9 @@ class MagicStarterPasswordConfirmDialog extends StatefulWidget {
 
 class _MagicStarterPasswordConfirmDialogState
     extends State<MagicStarterPasswordConfirmDialog> {
+  static const _iconVisible = Icons.visibility;
+  static const _iconHidden = Icons.visibility_off;
+
   final TextEditingController _passwordController = TextEditingController();
   bool _obscure = true;
   bool _isLoading = false;
@@ -174,7 +177,7 @@ class _MagicStarterPasswordConfirmDialogState
                     suffix: WAnchor(
                       onTap: () => setState(() => _obscure = !_obscure),
                       child: WIcon(
-                        _obscure ? Icons.visibility : Icons.visibility_off,
+                        _obscure ? _iconVisible : _iconHidden,
                         className: 'text-gray-400 text-xl',
                       ),
                     ),

--- a/lib/src/ui/widgets/magic_starter_team_selector.dart
+++ b/lib/src/ui/widgets/magic_starter_team_selector.dart
@@ -11,6 +11,9 @@ import '../../magic_starter_manager.dart';
 /// Displays the current team and allows switching between teams.
 /// Uses the team resolver registered via `MagicStarter.useTeamResolver()`.
 class MagicStarterTeamSelector extends StatelessWidget {
+  static const _iconCollapse = Icons.unfold_less;
+  static const _iconExpand = Icons.unfold_more;
+
   final bool compact;
 
   const MagicStarterTeamSelector({super.key, this.compact = false});
@@ -54,7 +57,7 @@ class MagicStarterTeamSelector extends StatelessWidget {
               ),
             ),
             WIcon(
-              isOpen ? Icons.unfold_less : Icons.unfold_more,
+              isOpen ? _iconCollapse : _iconExpand,
               className: 'text-gray-400 text-lg',
             ),
           ],

--- a/lib/src/ui/widgets/magic_starter_user_profile_dropdown.dart
+++ b/lib/src/ui/widgets/magic_starter_user_profile_dropdown.dart
@@ -29,6 +29,9 @@ class MagicStarterUserProfileDropdown extends StatelessWidget {
     this.triggerBuilder,
   });
 
+  static const _iconLightMode = Icons.light_mode_outlined;
+  static const _iconDarkMode = Icons.dark_mode_outlined;
+
   @override
   Widget build(BuildContext context) {
     return WPopover(
@@ -147,9 +150,7 @@ class MagicStarterUserProfileDropdown extends StatelessWidget {
               ),
             // Theme toggle — does not close dropdown on tap.
             _buildMenuItem(
-              icon: context.windIsDark
-                  ? Icons.light_mode_outlined
-                  : Icons.dark_mode_outlined,
+              icon: context.windIsDark ? _iconLightMode : _iconDarkMode,
               label: trans('common.toggle_theme'),
               onTap: () => context.windTheme.toggleTheme(),
             ),


### PR DESCRIPTION
## Summary
- Extract all runtime-conditional `Icons.*` references into `static const` fields across 10 files for Flutter web tree-shaking compatibility
- Converts ternary expressions and switch statements to use const fields/maps so `const_finder` can detect all icon glyphs
- Fixes 11+ broken icon usages that forced consumer apps to use `--no-tree-shake-icons` (+1.6MB)

Closes #37

## Test plan
- [x] `flutter analyze --no-fatal-infos` — zero issues
- [x] `flutter test` — 589 tests pass
- [x] No test modifications — pure refactor with no observable behavior change
- [x] Verify no `Icons.*` literals remain in ternary/switch expressions (only in `static const` declarations)