### PR TITLE
chore(release): 0.0.1-alpha.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.0.1-alpha.14] - 2026-04-16
+
 ### ✨ New Features
 - **Unified Theme System**: Added `MagicStarterTheme` with 7 sub-themes (`form`, `card`, `navigation`, `modal`, `layout`, `pageHeader`, `auth`) set all theme tokens in one call via `MagicStarter.useTheme()`
 - **Builder Slots**: Added `MagicStarter.view.slot()` for partial view customization — override specific sections (header, footer, sidebar) without replacing the entire view

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 Flutter starter kit for the Magic Framework. Pre-built Auth, Profile, Teams & Notifications — 13 opt-in features, every screen overridable via Wind UI.
 
-**Version:** 0.0.1-alpha.13 · **Dart:** >=3.6.0 · **Flutter:** >=3.27.0
+**Version:** 0.0.1-alpha.14 · **Dart:** >=3.6.0 · **Flutter:** >=3.27.0
 
 ## Commands
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: magic_starter
 description: Starter kit for Magic Framework. Auth, Profile, Teams, Notifications — 13 opt-in features with overridable views.
-version: 0.0.1-alpha.13
+version: 0.0.1-alpha.14
 homepage: https://magic.fluttersdk.com/starter
 documentation: https://magic.fluttersdk.com/packages/starter/getting-started/installation
 repository: https://github.com/fluttersdk/magic_starter


### PR DESCRIPTION
## Summary
- Bump version to `0.0.1-alpha.14`
- Move CHANGELOG entries from `[Unreleased]` to `[0.0.1-alpha.14]`
- Update CLAUDE.md version reference

## Release highlights
- Unified theme system with 7 sub-themes
- Builder slots for partial view customization
- Granular publish command with auto-wire
- Doctor: published view detection
- Cross-platform path handling in CLI
- Robust boot() injection logic