### PR TITLE
fix(layout): honor navigationTheme.brandBuilder in mobile header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### 🐛 Bug Fixes
-- **Mobile Header Brand**: `MagicStarterAppLayout` mobile topbar now honors `navigationTheme.brandBuilder` with the same fallback as the desktop sidebar, so custom brand widgets render consistently across breakpoints ([#65](https://github.com/fluttersdk/magic_starter/issues/65))
+- **Mobile Header Brand**: `MagicStarterAppLayout` mobile topbar now honors `navigationTheme.brandBuilder`, so custom brand widgets render consistently across breakpoints when provided ([#65](https://github.com/fluttersdk/magic_starter/issues/65))
 
 ## [0.0.1-alpha.14] - 2026-04-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### 🐛 Bug Fixes
+- **Mobile Header Brand**: `MagicStarterAppLayout` mobile topbar now honors `navigationTheme.brandBuilder` with the same fallback as the desktop sidebar, so custom brand widgets render consistently across breakpoints ([#65](https://github.com/fluttersdk/magic_starter/issues/65))
+
 ## [0.0.1-alpha.14] - 2026-04-16
 
 ### ✨ New Features

--- a/lib/src/ui/layouts/magic_starter_app_layout.dart
+++ b/lib/src/ui/layouts/magic_starter_app_layout.dart
@@ -221,6 +221,7 @@ class _MagicStarterAppLayoutState extends State<MagicStarterAppLayout> {
     if (isDesktop) return const SizedBox.shrink();
 
     final layoutTheme = MagicStarter.manager.layoutTheme;
+    final navTheme = MagicStarter.navigationTheme;
     return WDiv(
       className: layoutTheme.headerClassName,
       children: [
@@ -231,10 +232,12 @@ class _MagicStarterAppLayoutState extends State<MagicStarterAppLayout> {
             className: 'text-gray-600 dark:text-gray-300',
           ),
         ),
-        WText(
-          trans('app.name'),
-          className: 'font-bold text-lg text-gray-900 dark:text-white',
-        ),
+        navTheme.brandBuilder != null
+            ? navTheme.brandBuilder!(context)
+            : WText(
+                trans('app.name'),
+                className: 'font-bold text-lg text-gray-900 dark:text-white',
+              ),
         WDiv(
           className: 'flex items-center gap-1',
           children: [

--- a/test/ui/layouts/magic_starter_app_layout_test.dart
+++ b/test/ui/layouts/magic_starter_app_layout_test.dart
@@ -476,6 +476,63 @@ void main() {
     );
   });
 
+  group('MagicStarterAppLayout mobile header brand', () {
+    testWidgets(
+      'mobile header renders brandBuilder when set',
+      (tester) async {
+        tester.view.physicalSize = const Size(400, 800);
+        tester.view.devicePixelRatio = 1.0;
+
+        addTearDown(() {
+          tester.view.resetPhysicalSize();
+          tester.view.resetDevicePixelRatio();
+        });
+
+        const brandKey = Key('custom-brand-builder');
+        MagicStarter.useNavigationTheme(
+          MagicStarterNavigationTheme(
+            brandBuilder: (_) => const SizedBox(
+              key: brandKey,
+              width: 10,
+              height: 10,
+            ),
+          ),
+        );
+
+        await tester.pumpWidget(
+          createApp(
+            child: const SizedBox(),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.byKey(brandKey), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'mobile header falls back to WText when brandBuilder is null',
+      (tester) async {
+        tester.view.physicalSize = const Size(400, 800);
+        tester.view.devicePixelRatio = 1.0;
+
+        addTearDown(() {
+          tester.view.resetPhysicalSize();
+          tester.view.resetDevicePixelRatio();
+        });
+
+        await tester.pumpWidget(
+          createApp(
+            child: const SizedBox(),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text(trans('app.name')), findsWidgets);
+      },
+    );
+  });
+
   group('MagicStarterAppLayout sidebar navigation scroll', () {
     testWidgets(
       'sidebar does not overflow with many nav items in short viewport',

--- a/test/ui/layouts/magic_starter_app_layout_test.dart
+++ b/test/ui/layouts/magic_starter_app_layout_test.dart
@@ -506,7 +506,20 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(find.byKey(brandKey), findsOneWidget);
+        // Scope to the header row: the ancestor of the menu icon is the mobile
+        // header. The drawer also uses brandBuilder, so a global finder cannot
+        // prove the header specifically renders it.
+        final headerFinder = find
+            .ancestor(
+              of: find.byIcon(Icons.menu),
+              matching: find.byType(WDiv),
+            )
+            .first;
+
+        expect(
+          find.descendant(of: headerFinder, matching: find.byKey(brandKey)),
+          findsOneWidget,
+        );
       },
     );
 
@@ -528,7 +541,22 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(find.text(trans('app.name')), findsWidgets);
+        // Scope to the header row: app.name can also appear in the drawer, so
+        // a global text finder cannot prove the header fallback specifically.
+        final headerFinder = find
+            .ancestor(
+              of: find.byIcon(Icons.menu),
+              matching: find.byType(WDiv),
+            )
+            .first;
+
+        expect(
+          find.descendant(
+            of: headerFinder,
+            matching: find.text(trans('app.name')),
+          ),
+          findsOneWidget,
+        );
       },
     );
   });


### PR DESCRIPTION
## Summary
- Mobile topbar in `MagicStarterAppLayout._buildHeader` now renders `navigationTheme.brandBuilder(context)` when set, falling back to the existing `WText(trans('app.name'))` otherwise — matching the desktop sidebar's `_buildBrand` behavior.
- Adds two widget tests covering the brandBuilder path and the default text fallback on a mobile viewport.
- Updates `CHANGELOG.md` under `[Unreleased]`.

Closes #65

## Test plan
- [x] `flutter test test/ui/layouts/magic_starter_app_layout_test.dart` — all 8 tests pass
- [x] `flutter analyze --no-fatal-infos` — no new issues
- [x] `dart format .` — clean
- [ ] Visual smoke: consumer app with `MagicStarter.useNavigationTheme(brandBuilder: ...)` shows the same brand widget on mobile and desktop
- [ ] Visual smoke: consumer app without `brandBuilder` still shows `trans('app.name')` in the mobile header