### PR TITLE
feat: declare bootstrap_command so plugin:install scaffolds the starter (#4b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this project will be documented in this file.
 - **Removed magic_cli dependency**: CLI now builds on `fluttersdk_artisan ^0.0.8`.
 
 ### Changed
+- **plugin:install auto-scaffolds starter**: `install.yaml` now declares `bootstrap_command: starter:install` so `plugin:install magic_starter` automatically runs the full starter scaffold (config, routes, middleware, dashboard) without a separate manual step. Requires `fluttersdk_artisan ^0.0.9` which introduced auto-execution of the `bootstrap_command` field. Pass `--no-bootstrap` to skip the auto-run.
+- **post_install message**: updated install completion message to reflect that `starter:install` now runs automatically. The message documents the `--no-bootstrap` opt-out and directs users to `starter:configure` for feature adjustments.
 - **Install is manifest-driven** — static scaffolding (config publish, provider injection) now driven by `install.yaml` manifest; dynamic logic (feature toggles, interactive mode) handled by fluent override in `MagicStarterInstallCommand`.
 
 ### Added

--- a/install.yaml
+++ b/install.yaml
@@ -30,10 +30,18 @@ magic:
   # package:magic_starter/magic_starter.dart (derived from plugin_name).
   provider: MagicStarterServiceProvider
 
+bootstrap_command: starter:install
+
 post_install:
   message: |
-    Magic Starter installed. Next steps:
+    Magic Starter installed.
 
-    1. Review lib/config/magic_starter.dart feature toggles. Re-run
-       `dart run <app>:artisan starter:configure` to adjust them.
-    2. Run `flutter pub get && flutter run` to verify the bootstrap.
+    `starter:install` ran automatically and scaffolded your config, route
+    registrations, middleware, and dashboard with all opt-in features
+    disabled (safe defaults). Use `dart run <app>:artisan starter:configure`
+    to enable features afterward.
+
+    To skip the automatic scaffold on future installs, pass `--no-bootstrap`
+    to `plugin:install`.
+
+    Run `flutter pub get && flutter run` to verify the setup.


### PR DESCRIPTION
## What

Add `bootstrap_command: starter:install` to `install.yaml` so that `plugin:install magic_starter` auto-runs the full starter scaffold (config, routes, middleware, dashboard) as a `--non-interactive` subprocess. Rewrite `post_install` to reflect the automatic scaffold and the `--no-bootstrap` opt-out.

## Why

Generic `plugin:install` only injected the provider; the full scaffold lived behind a manual `starter:install`. Pairs with the artisan auto-run (fluttersdk/artisan#32). Non-interactive scaffolds with all opt-in features disabled; users enable them afterward via `starter:configure`.

## Verification

`flutter analyze --no-fatal-infos` clean. `bootstrap_command` confirmed as a parseable top-level manifest field. Live end-to-end is gated on publishing artisan 0.0.9 (consumer currently pins 0.0.8); verified by parts until then.

Addresses REPORT.md #4 (magic_starter side). Depends on fluttersdk/artisan#32.