### PR TITLE
fix: open the newly created team's settings after create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **Create team opens the new team's settings**: `MagicStarterTeamController.activeTeamName` now resolves the name from the team resolver's `allTeams()` keyed by `activeTeamId`, falling back to `currentTeam()`. Previously `activeTeamId` preferred the local `currentTeamId` notifier (set on create/switch) while `activeTeamName` read only the resolver's `currentTeam()`, so after creating a team the settings view pre-filled the OLD team's name and effectively opened the old team ([#14](https://github.com/fluttersdk/magic_starter/issues/14)).
+
 ### Removed
 - **Breaking: Standalone CLI entrypoint** — removed `bin/magic_starter.dart` and `dart run magic_starter:*` commands. Commands now surface via the host app's artisan dispatcher. Migrate: `dart run magic_starter:install` becomes `dart run <app>:artisan starter:install` (register `StarterArtisanProvider` in your app's `artisan.providers` list).
 - **Removed magic_cli dependency**: CLI now builds on `fluttersdk_artisan ^0.0.8`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Fixed
-- **Create team opens the new team's settings**: `MagicStarterTeamController.activeTeamName` now resolves the name from the team resolver's `allTeams()` keyed by `activeTeamId`, falling back to `currentTeam()`. Previously `activeTeamId` preferred the local `currentTeamId` notifier (set on create/switch) while `activeTeamName` read only the resolver's `currentTeam()`, so after creating a team the settings view pre-filled the OLD team's name and effectively opened the old team ([#14](https://github.com/fluttersdk/magic_starter/issues/14)).
+- **Create team opens the new team's settings**: `MagicStarterTeamController.activeTeamName` now matches the local `currentTeamId` (when set) against the resolver's `allTeams()` by id, falling back to the resolver's `currentTeam()` when no match exists. Previously `activeTeamId` preferred the local `currentTeamId` notifier (set on create/switch) while `activeTeamName` read only the resolver's `currentTeam()`, so after creating a team the settings view pre-filled the OLD team's name and effectively opened the old team ([#14](https://github.com/fluttersdk/magic_starter/issues/14)).
 
 ### Removed
 - **Breaking: Standalone CLI entrypoint** — removed `bin/magic_starter.dart` and `dart run magic_starter:*` commands. Commands now surface via the host app's artisan dispatcher. Migrate: `dart run magic_starter:install` becomes `dart run <app>:artisan starter:install` (register `StarterArtisanProvider` in your app's `artisan.providers` list).

--- a/lib/src/http/controllers/magic_starter_team_controller.dart
+++ b/lib/src/http/controllers/magic_starter_team_controller.dart
@@ -25,8 +25,27 @@ class MagicStarterTeamController extends MagicController
   dynamic get activeTeamId =>
       currentTeamId.value ?? MagicStarter.teamResolver?.currentTeam()?.id;
 
-  /// Get the active team name from the resolver.
-  String? get activeTeamName => MagicStarter.teamResolver?.currentTeam()?.name;
+  /// Get the active team name, consistent with [activeTeamId].
+  ///
+  /// When a team has been explicitly selected or just created
+  /// ([currentTeamId] set), the name is resolved from the resolver's
+  /// `allTeams()` by matching [activeTeamId]. This keeps the displayed name in
+  /// step with [activeTeamId] so the settings view opens the newly created (or
+  /// switched) team, not the resolver's previously current one. Falls back to
+  /// the resolver's `currentTeam()` when no local selection or match exists.
+  String? get activeTeamName {
+    final resolver = MagicStarter.teamResolver;
+    if (resolver == null) return null;
+
+    final localId = currentTeamId.value;
+    if (localId != null) {
+      for (final team in resolver.allTeams()) {
+        if (team.id == localId) return team.name;
+      }
+    }
+
+    return resolver.currentTeam()?.name;
+  }
 
   /// Render create team view via registry key.
   Widget create() => MagicStarter.view.make('teams.create');

--- a/test/http/controllers/magic_starter_team_controller_test.dart
+++ b/test/http/controllers/magic_starter_team_controller_test.dart
@@ -291,6 +291,51 @@ void main() {
         expect(postCalls, hasLength(1));
       });
 
+      // REPORT #14: after creating a team, the team settings view opens the
+      // OLD team's settings. The settings view pre-fills its name field from
+      // [activeTeamName] (controller :29). The seam is the divergence between
+      // [activeTeamId] (prefers the local currentTeamId notifier) and
+      // [activeTeamName] (reads only the resolver, which still points at the
+      // previously active team because the new team is not yet the resolver's
+      // current team). After create, both getters must agree on the new team.
+      test(
+        'after create: activeTeamName reflects the new team, not the old one',
+        () async {
+          // The resolver simulates the consumer wiring: its "current team" is
+          // still the OLD team (id 1) because the resolver keys off a list that
+          // has not re-pointed at the freshly created team yet. The new team
+          // IS present in allTeams (the user belongs to it server-side).
+          const oldTeam = MagicStarterTeam(id: 1, name: 'Old Team');
+          const newTeam = MagicStarterTeam(id: 10, name: 'New Team');
+          MagicStarter.manager.teamResolver = MagicStarterTeamResolverConfig(
+            currentTeam: () => oldTeam,
+            allTeams: () => const [oldTeam, newTeam],
+            onSwitch: (_) async {},
+          );
+
+          mockDriver.stubResponse(
+            '/teams',
+            statusCode: 200,
+            data: {
+              'data': {
+                'id': 10,
+                'name': 'New Team',
+              },
+            },
+          );
+
+          await controller.doCreate(name: 'New Team');
+
+          // activeTeamId already prefers the local notifier and is correct.
+          expect(controller.activeTeamId, equals(10));
+
+          // The bug: activeTeamName returns 'Old Team' because it reads only
+          // the resolver's currentTeam(). It must reflect the new team so the
+          // settings view opens the new team, not the old one.
+          expect(controller.activeTeamName, equals('New Team'));
+        },
+      );
+
       test('failure (422) — returns false, sets error', () async {
         mockDriver.stubResponse(
           '/teams',

--- a/test/http/controllers/magic_starter_team_controller_test.dart
+++ b/test/http/controllers/magic_starter_team_controller_test.dart
@@ -293,7 +293,7 @@ void main() {
 
       // REPORT #14: after creating a team, the team settings view opens the
       // OLD team's settings. The settings view pre-fills its name field from
-      // [activeTeamName] (controller :29). The seam is the divergence between
+      // [activeTeamName]. The seam is the divergence between
       // [activeTeamId] (prefers the local currentTeamId notifier) and
       // [activeTeamName] (reads only the resolver, which still points at the
       // previously active team because the new team is not yet the resolver's


### PR DESCRIPTION
Fixes REPORT friction item #14.

`activeTeamName` read the resolver's `currentTeam()` callback while `activeTeamId` preferred the local `currentTeamId` notifier, so after creating a team the settings view pre-filled the OLD team's name. `activeTeamName` now resolves the local id against the resolver's `allTeams()`, staying consistent with `activeTeamId`.

Reproduce-first: the obvious "un-awaited Auth.restore()" theory was disproven (the code already awaits); the real seam was the getter divergence, confirmed by a red-green-red test. analyze 0, format 0-diff, team controller suite 20 pass. The teamResolver contract is untouched.