### PR TITLE
test: target wind 1.1.x WInput via descendant finder in widget tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ All notable changes to this project will be documented in this file.
 - **Mobile Header Brand**: `MagicStarterAppLayout` mobile topbar now honors `navigationTheme.brandBuilder`, so custom brand widgets render consistently across breakpoints when provided ([#65](https://github.com/fluttersdk/magic_starter/issues/65))
 - **Page Header Title Truncation**: `MagicStarterPageHeaderTheme` defaults now use `line-clamp-2` instead of `truncate` for `titleClassName` and `subtitleClassName`, so long titles wrap to a second line on narrow viewports (e.g. iPhone-width screens) instead of clipping to "AI sett..." ([#67](https://github.com/fluttersdk/magic_starter/issues/67))
 
+### 🧪 Tests
+- **wind 1.1.x widget-test compatibility**: the two-factor modal and password confirm dialog widget tests drove input via `find.byType(TextField)`, which broke once CI resolved `fluttersdk_wind` 1.1.x (the Material-free `WInput`/`WFormInput` rewrite renders an `EditableText` instead of a Material `TextField`). Both files now resolve the field via `find.descendant(of: find.byType(WFormInput), matching: find.byType(EditableText))`, scoping the search to the single form input so the two-factor setup step's selectable secret-key `EditableText` is not matched by accident.
+
 ## [0.0.1-alpha.14] - 2026-04-16
 
 ### ✨ New Features

--- a/test/ui/widgets/magic_starter_password_confirm_dialog_test.dart
+++ b/test/ui/widgets/magic_starter_password_confirm_dialog_test.dart
@@ -3,6 +3,17 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:magic/magic.dart';
 import 'package:magic_starter/magic_starter.dart';
 
+/// Resolves the password input inside [MagicStarterPasswordConfirmDialog].
+///
+/// Under wind 1.1.x the `WInput`/`WFormInput` rewrite is Material-free and no
+/// longer renders a `TextField`, so `find.byType(TextField)` finds nothing.
+/// Scoping the search to the single `WFormInput` pins the password field via
+/// its underlying `EditableText` without depending on the Material widget tree.
+final Finder passwordInput = find.descendant(
+  of: find.byType(WFormInput),
+  matching: find.byType(EditableText),
+);
+
 void main() {
   setUp(() async {
     MagicApp.reset();
@@ -110,8 +121,7 @@ void main() {
     await tester.pumpAndSettle();
 
     // Enter password and tap confirm
-    final textField = find.byType(TextField);
-    await tester.enterText(textField, 'wrongpass');
+    await tester.enterText(passwordInput, 'wrongpass');
     await tester.tap(find.text('common.confirm'));
     await tester.pumpAndSettle();
 
@@ -148,8 +158,7 @@ void main() {
     await tester.pumpAndSettle();
 
     // Find the text field inside WFormInput and enter text
-    final textField = find.byType(TextField);
-    await tester.enterText(textField, 'secretpassword');
+    await tester.enterText(passwordInput, 'secretpassword');
     await tester.pump();
 
     await tester.tap(find.text('common.confirm'));

--- a/test/ui/widgets/magic_starter_password_confirm_dialog_test.dart
+++ b/test/ui/widgets/magic_starter_password_confirm_dialog_test.dart
@@ -157,7 +157,7 @@ void main() {
     await tester.tap(find.text('Show'));
     await tester.pumpAndSettle();
 
-    // Find the text field inside WFormInput and enter text
+    // Enter text into the password input (EditableText inside WFormInput)
     await tester.enterText(passwordInput, 'secretpassword');
     await tester.pump();
 

--- a/test/ui/widgets/magic_starter_two_factor_modal_test.dart
+++ b/test/ui/widgets/magic_starter_two_factor_modal_test.dart
@@ -11,8 +11,9 @@ import 'package:magic_starter/magic_starter.dart';
 /// Resolves the OTP input inside [MagicStarterTwoFactorModal].
 ///
 /// Under wind 1.1.x the `WInput`/`WFormInput` rewrite is Material-free and no
-/// longer renders a `TextField`, so `otpInput` finds nothing.
-/// A bare `find.byType(EditableText)` is also wrong: the setup step renders the
+/// longer renders a `TextField`, so the old `find.byType(TextField)` finds
+/// nothing. A bare `find.byType(EditableText)` is also wrong: the setup step
+/// renders the
 /// secret key via a `selectable` `WText`, which hosts a second read-only
 /// `EditableText`. Scoping the search to the single `WFormInput` pins the OTP
 /// field unambiguously.

--- a/test/ui/widgets/magic_starter_two_factor_modal_test.dart
+++ b/test/ui/widgets/magic_starter_two_factor_modal_test.dart
@@ -8,6 +8,19 @@ import 'package:magic_starter/magic_starter.dart';
 /// RED PHASE — [MagicStarterTwoFactorModal] does NOT exist yet.
 /// These tests define the contract for the 2FA setup wizard modal
 /// and MUST fail until Task 4 provides the implementation.
+/// Resolves the OTP input inside [MagicStarterTwoFactorModal].
+///
+/// Under wind 1.1.x the `WInput`/`WFormInput` rewrite is Material-free and no
+/// longer renders a `TextField`, so `otpInput` finds nothing.
+/// A bare `find.byType(EditableText)` is also wrong: the setup step renders the
+/// secret key via a `selectable` `WText`, which hosts a second read-only
+/// `EditableText`. Scoping the search to the single `WFormInput` pins the OTP
+/// field unambiguously.
+final Finder otpInput = find.descendant(
+  of: find.byType(WFormInput),
+  matching: find.byType(EditableText),
+);
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -143,7 +156,7 @@ void main() {
       );
 
       // Enter a valid-looking 6-digit code and tap confirm.
-      await tester.enterText(find.byType(TextField), '123456');
+      await tester.enterText(otpInput, '123456');
       await tester.pump();
 
       await tester.tap(find.text('common.confirm'));
@@ -177,7 +190,7 @@ void main() {
       expect(find.byType(WSvg), findsOneWidget);
 
       // Simulate entering a 6-digit OTP and confirming.
-      await tester.enterText(find.byType(TextField), '654321');
+      await tester.enterText(otpInput, '654321');
       await tester.pump();
 
       await tester.tap(find.text('common.confirm'));
@@ -201,7 +214,7 @@ void main() {
         onConfirm: (_) async => false,
       );
 
-      await tester.enterText(find.byType(TextField), '000000');
+      await tester.enterText(otpInput, '000000');
       await tester.pump();
 
       await tester.tap(find.text('common.confirm'));
@@ -299,7 +312,7 @@ void main() {
       expect(find.byType(WSvg), findsOneWidget);
 
       // Enter OTP and confirm.
-      await tester.enterText(find.byType(TextField), '123456');
+      await tester.enterText(otpInput, '123456');
       await tester.pump();
 
       await tester.tap(find.text('common.confirm'));
@@ -392,7 +405,7 @@ void main() {
       );
 
       // Enter a valid 6-digit code and tap confirm to advance to recovery step.
-      await tester.enterText(find.byType(TextField), '123456');
+      await tester.enterText(otpInput, '123456');
       await tester.pump();
 
       await tester.tap(find.text('common.confirm'));
@@ -427,7 +440,7 @@ void main() {
       );
 
       // Enter a valid 6-digit code and tap confirm.
-      await tester.enterText(find.byType(TextField), '123456');
+      await tester.enterText(otpInput, '123456');
       await tester.pump();
 
       await tester.tap(find.text('common.confirm'));


### PR DESCRIPTION
**Pre-existing main breakage** (not introduced by a feature PR). CI on `main` is red: `two_factor_modal` and `password_confirm_dialog` widget tests drove input with `enterText(find.byType(TextField))`, but wind 1.1.x's Material-free `WInput`/`WFormInput` rewrite no longer renders a Material `TextField` (and the 2FA modal's `selectable` secret-key `WText` adds a second, read-only `EditableText`, so a bare `EditableText` finder is also ambiguous).

Targets the input via `find.descendant(of: find.byType(WFormInput), matching: find.byType(EditableText))`, which resolves to exactly one match in both widgets. Test-only change, no widget source touched. Full suite: 764 pass.