### PR TITLE
fix: stop post_install message from claiming the bootstrap succeeded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - **plugin:install auto-scaffolds starter**: `install.yaml` now declares `bootstrap_command: starter:install` so `plugin:install magic_starter` automatically runs the full starter scaffold (config, routes, middleware, dashboard) without a separate manual step. Requires `fluttersdk_artisan ^0.0.9` which introduced auto-execution of the `bootstrap_command` field. Pass `--no-bootstrap` to skip the auto-run.
-- **post_install message**: updated install completion message to reflect that `starter:install` now runs automatically. The message documents the `--no-bootstrap` opt-out and directs users to `starter:configure` for feature adjustments.
+- **post_install message**: reworded so it no longer flatly claims the `starter:install` bootstrap succeeded (a chained-bootstrap failure previously left the message asserting a scaffold that never happened). It now tells the operator to run `dart run <app>:artisan starter:install` by hand if the bootstrap exited non-zero or `lib/config/magic_starter.dart` is missing, shows the `--features=` one-liner, and documents the `--no-bootstrap` opt-out. Pairs with `fluttersdk_artisan`'s fix that surfaces a non-zero bootstrap exit code.
 - **Install is manifest-driven** — static scaffolding (config publish, provider injection) now driven by `install.yaml` manifest; dynamic logic (feature toggles, interactive mode) handled by fluent override in `MagicStarterInstallCommand`.
 
 ### Added

--- a/install.yaml
+++ b/install.yaml
@@ -34,14 +34,19 @@ bootstrap_command: starter:install
 
 post_install:
   message: |
-    Magic Starter installed.
+    Magic Starter provider registered.
 
-    `starter:install` ran automatically and scaffolded your config, route
-    registrations, middleware, and dashboard with all opt-in features
-    disabled (safe defaults). Use `dart run <app>:artisan starter:configure`
-    to enable features afterward.
+    The `starter:install` bootstrap is chained automatically to scaffold your
+    config, route registrations, middleware, models, and dashboard (all opt-in
+    features disabled by default). If the bootstrap reported a non-zero exit
+    above, or `lib/config/magic_starter.dart` is missing, run it by hand:
+
+      dart run <app>:artisan starter:install
+
+    Then enable features with `dart run <app>:artisan starter:configure`, or
+    install with features directly:
+
+      dart run <app>:artisan starter:install --features=registration,teams,sessions
 
     To skip the automatic scaffold on future installs, pass `--no-bootstrap`
-    to `plugin:install`.
-
-    Run `flutter pub get && flutter run` to verify the setup.
+    to `plugin:install`. Finally: `flutter pub get && flutter run`.


### PR DESCRIPTION
## Summary
The `install.yaml` `post_install` message stated that `starter:install` *'ran automatically and scaffolded your config, route registrations, middleware, and dashboard'*. When the chained bootstrap actually fails (now surfaced by the [`fluttersdk_artisan` bootstrap-exit-code fix](https://github.com/fluttersdk/artisan/pull/34)), this message asserted a scaffold that never happened and gave the operator no recovery path. A from-scratch install QA hit this: config was missing yet the message claimed success, and `starter:configure --show` then errored 'config not found'.

## Change
Reworded the message to:
- describe the bootstrap as *chained* (not guaranteed),
- tell the operator to run `dart run <app>:artisan starter:install` by hand if the bootstrap exited non-zero or `lib/config/magic_starter.dart` is missing,
- show the `--features=` one-liner,
- document the `--no-bootstrap` opt-out.

## Verification
Out-of-box re-verify on a fresh app: `plugin:install magic_starter` wrote config + middleware + models + dashboard, and `starter:configure --show` works.

Author: Anılcan Çakır <anilcan.cakir@gmail.com>