### PR TITLE
fix(a11y): label the notification toggles and drop the duplicate label node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,9 @@ All notable changes to this project will be documented in this file.
 ### 🧪 Tests
 - **wind 1.1.x widget-test compatibility**: the two-factor modal and password confirm dialog widget tests drove input via `find.byType(TextField)`, which broke once CI resolved `fluttersdk_wind` 1.1.x (the Material-free `WInput`/`WFormInput` rewrite renders an `EditableText` instead of a Material `TextField`). Both files now resolve the field via `find.descendant(of: find.byType(WFormInput), matching: find.byType(EditableText))`, scoping the search to the single form input so the two-factor setup step's selectable secret-key `EditableText` is not matched by accident.
 
+### Fixed
+- **Notification-preference toggles now carry an accessible name and expose a single Semantics node.** Each channel toggle (`MSSwitch`) had no `semanticLabel` and sat beside a visible `WText` of the same channel name, so a screen reader announced a bare "switch" while the row exposed TWO nodes sharing the label. The switch now takes `semanticLabel: <channel name>` and the visible label is wrapped in `ExcludeSemantics`, so the row exposes one correctly named toggle. This also gives an accessibility / E2E lookup a single stable target instead of resolving the inert text first. Touches `lib/src/ui/views/notifications/magic_starter_notification_preferences_view.dart`.
+
 ## [0.0.1-alpha.14] - 2026-04-16
 
 ### ✨ New Features

--- a/lib/src/ui/views/notifications/magic_starter_notification_preferences_view.dart
+++ b/lib/src/ui/views/notifications/magic_starter_notification_preferences_view.dart
@@ -172,15 +172,27 @@ class _MagicStarterNotificationPreferencesViewState
                 ''',
               ),
             ),
-            WText(
-              _channelLabel(channel),
-              className: 'text-sm font-medium text-fg',
+            // The switch below carries this same text as its semanticLabel, so
+            // exclude the visible copy from semantics: otherwise the row exposes
+            // TWO nodes with the same name (this paragraph AND the switch) and a
+            // getByLabel / E2E lookup resolves the non-interactive text first,
+            // landing the tap on the label instead of the toggle.
+            ExcludeSemantics(
+              child: WText(
+                _channelLabel(channel),
+                className: 'text-sm font-medium text-fg',
+              ),
             ),
           ],
         ),
         MSSwitch(
           value: isEnabled,
           disabled: isLocked,
+          // Label the toggle with its visible channel name: the channel text is
+          // a sibling WText, so without this the switch had no accessible name
+          // (a screen reader announced a bare "switch") and no stable handle
+          // for an E2E driver to resolve.
+          semanticLabel: _channelLabel(channel),
           onChanged: (newValue) {
             controller.updateTypePreference(
               type,


### PR DESCRIPTION
## What

Each notification-preference channel toggle (`MSSwitch`) had no `semanticLabel` and sat beside a visible `WText` of the same channel name. A screen reader announced a bare "switch", and the row exposed TWO Semantics nodes sharing the label, so an accessibility / E2E lookup resolved the inert text first (the tap landed on the label, not the toggle).

## Fix

Give the switch `semanticLabel: <channel name>` and wrap the visible label in `ExcludeSemantics`, so the row exposes one correctly named toggle with a single stable target.

## Notes

- Single file: `lib/src/ui/views/notifications/magic_starter_notification_preferences_view.dart`.
- CHANGELOG updated under `[Unreleased] > Fixed`.
- **Stacked PR**: based on `refactor/account-semantic-tokens` (#79), which touches the same view. GitHub will retarget this to `main` once #79 merges. Review this PR's own diff (the last commit) for the a11y change.