### PR TITLE
Add optional pushProvisioned hint to notification preferences view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **`pushProvisioned` hint on the notification preferences view**: `MagicStarterNotificationPreferencesView` gains an optional `bool pushProvisioned = true`. A host whose push integration is not provisioned yet (an empty OneSignal `app_id`, for example) passes `false`, and a subtle hint renders under the push channel label so the user understands why the toggle cannot deliver. Additive and backward compatible: a consumer that does not thread the flag keeps the current rendering. The hint reads from the new `notifications.channel_push_unconfigured` lang key (added to the published `en` lang stub), so a consumer that installed an earlier stub should add that key to keep the hint translated. The hint deliberately stays OUTSIDE the label's `ExcludeSemantics` (the exclusion exists so an E2E label lookup resolves the switch, not the text), because it carries information the switch label does not and a screen reader has to announce it.
+
 ### Changed
 - **Account views now style through the semantic alias tokens instead of raw Tailwind gray classes.** The auth screens (login, register, forgot / reset password, OTP verify), the profile and notification views, the team settings / invitation views, the app layout, and the password-confirm / two-factor dialogs used literal `gray-*` classes for their surfaces, borders, and text. They now map to the semantic aliases (`bg-surface*`, `text-fg*`, `border-color-border*`), so a consumer's theme and dark-mode pairs drive them and the account surface matches the rest of the design system. Pure class-name refactor, no behavior change. Touches the auth / profile / teams views under `lib/src/ui/views/`, `lib/src/ui/layouts/magic_starter_app_layout.dart`, and the `magic_starter_password_confirm_dialog` / `magic_starter_two_factor_modal` widgets.
 

--- a/assets/stubs/install/en.stub
+++ b/assets/stubs/install/en.stub
@@ -192,7 +192,8 @@
     "no_preferences": "No notification preferences available.",
     "channel_email": "Email",
     "channel_in_app": "In-App",
-    "channel_push": "Push"
+    "channel_push": "Push",
+    "channel_push_unconfigured": "Push not yet configured"
   },
   "profile": {
     "browser_sessions": "Browser Sessions",

--- a/lib/src/ui/views/notifications/magic_starter_notification_preferences_view.dart
+++ b/lib/src/ui/views/notifications/magic_starter_notification_preferences_view.dart
@@ -186,28 +186,29 @@ class _MagicStarterNotificationPreferencesViewState
                 ''',
               ),
             ),
-            // The switch below carries this same text as its semanticLabel, so
-            // exclude the visible copy from semantics: otherwise the row exposes
-            // TWO nodes with the same name (this paragraph AND the switch) and a
-            // getByLabel / E2E lookup resolves the non-interactive text first,
-            // landing the tap on the label instead of the toggle.
-            ExcludeSemantics(
-              child: WDiv(
-                className: 'flex flex-col gap-1',
-                children: [
-                  WText(
+            WDiv(
+              className: 'flex flex-col gap-1',
+              children: [
+                // The switch below carries this same text as its semanticLabel,
+                // so exclude the visible copy from semantics: otherwise the row
+                // exposes TWO nodes with the same name (this paragraph AND the
+                // switch) and a getByLabel / E2E lookup resolves the
+                // non-interactive text first, landing the tap on the label
+                // instead of the toggle. The hint below stays OUT of the
+                // exclusion: it carries information the switch label does not,
+                // so a screen reader has to announce it.
+                ExcludeSemantics(
+                  child: WText(
                     _channelLabel(channel),
                     className: 'text-sm font-medium text-fg',
                   ),
-                  if (showPushHint)
-                    WText(
-                      // No lang key ships for this hint and the lang assets are
-                      // out of this step's file scope; see `### Deviations`.
-                      'Push not yet configured',
-                      className: 'text-xs text-fg-muted',
-                    ),
-                ],
-              ),
+                ),
+                if (showPushHint)
+                  WText(
+                    trans('notifications.channel_push_unconfigured'),
+                    className: 'text-xs text-fg-muted',
+                  ),
+              ],
             ),
           ],
         ),

--- a/lib/src/ui/views/notifications/magic_starter_notification_preferences_view.dart
+++ b/lib/src/ui/views/notifications/magic_starter_notification_preferences_view.dart
@@ -15,7 +15,17 @@ import '../../widgets/magic_starter_page_header.dart';
 /// Each notification type shows its available channels as toggle switches with icons.
 class MagicStarterNotificationPreferencesView
     extends MagicStatefulView<MagicStarterNotificationController> {
-  const MagicStarterNotificationPreferencesView({super.key});
+  const MagicStarterNotificationPreferencesView({
+    super.key,
+    this.pushProvisioned = true,
+  });
+
+  /// Whether the host app has provisioned its push integration (for example a
+  /// non-empty OneSignal `app_id`). When `false`, a subtle "push not yet
+  /// configured" hint renders beneath the push channel toggle so the user
+  /// understands the toggle cannot deliver yet. Defaults to `true` so existing
+  /// consumers that do not thread this flag keep their current behavior.
+  final bool pushProvisioned;
 
   @override
   State<MagicStarterNotificationPreferencesView> createState() =>
@@ -148,6 +158,10 @@ class _MagicStarterNotificationPreferencesViewState
     final bool isEnabled = channelData['enabled'] as bool? ?? false;
     final bool isLocked = channelData['locked'] as bool? ?? false;
     final icon = _channelIcon(channel);
+    // The push channel toggle cannot deliver until the host provisions its push
+    // integration; surface a subtle heads-up beneath its label when it has not.
+    final bool showPushHint =
+        channel.toLowerCase() == 'push' && !widget.pushProvisioned;
 
     return WDiv(
       className: '''
@@ -178,9 +192,21 @@ class _MagicStarterNotificationPreferencesViewState
             // getByLabel / E2E lookup resolves the non-interactive text first,
             // landing the tap on the label instead of the toggle.
             ExcludeSemantics(
-              child: WText(
-                _channelLabel(channel),
-                className: 'text-sm font-medium text-fg',
+              child: WDiv(
+                className: 'flex flex-col gap-1',
+                children: [
+                  WText(
+                    _channelLabel(channel),
+                    className: 'text-sm font-medium text-fg',
+                  ),
+                  if (showPushHint)
+                    WText(
+                      // No lang key ships for this hint and the lang assets are
+                      // out of this step's file scope; see `### Deviations`.
+                      'Push not yet configured',
+                      className: 'text-xs text-fg-muted',
+                    ),
+                ],
               ),
             ),
           ],

--- a/test/ui/views/notifications/magic_starter_notification_preferences_view_test.dart
+++ b/test/ui/views/notifications/magic_starter_notification_preferences_view_test.dart
@@ -184,6 +184,98 @@ void main() {
     });
   });
 
+  group('MagicStarterNotificationPreferencesView — push hint', () {
+    /// Mock a matrix carrying a push channel plus one non-push sibling.
+    void mockPushMatrix() {
+      mockDriver.mockResponse(statusCode: 200, data: {
+        'data': {
+          'monitor_down': {
+            'label': 'Monitor Down Alert',
+            'channels': {
+              'push': {'enabled': true, 'locked': false},
+              'mail': {'enabled': true, 'locked': false},
+            }
+          }
+        }
+      });
+    }
+
+    /// Widen the surface: no lang loader runs here, so trans() yields the raw
+    /// key and the hint is far wider than its translated copy.
+    void widen(WidgetTester tester) {
+      tester.view.physicalSize = const Size(1920, 1080);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+    }
+
+    testWidgets('renders the hint under push when push is not provisioned',
+        (tester) async {
+      widen(tester);
+      mockPushMatrix();
+
+      await tester.pumpWidget(wrap(
+        const MagicStarterNotificationPreferencesView(
+          pushProvisioned: false,
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text(trans('notifications.channel_push_unconfigured')),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('renders no hint when push is provisioned (the default)',
+        (tester) async {
+      widen(tester);
+      mockPushMatrix();
+
+      await tester
+          .pumpWidget(wrap(const MagicStarterNotificationPreferencesView()));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text(trans('notifications.channel_push_unconfigured')),
+        findsNothing,
+      );
+    });
+
+    testWidgets('keeps the hint out of the label semantics exclusion',
+        (tester) async {
+      widen(tester);
+      mockPushMatrix();
+
+      await tester.pumpWidget(wrap(
+        const MagicStarterNotificationPreferencesView(
+          pushProvisioned: false,
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      // The channel label is excluded (the switch carries it as its
+      // semanticLabel), but the hint must stay announceable: it says something
+      // the switch label does not.
+      expect(
+        find.descendant(
+          of: find.byType(ExcludeSemantics),
+          matching: find.text(trans('notifications.channel_push')),
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.descendant(
+          of: find.byType(ExcludeSemantics),
+          matching: find.text(trans('notifications.channel_push_unconfigured')),
+        ),
+        findsNothing,
+      );
+    });
+  });
+
   group('MagicStarterNotificationPreferencesView — slot injection', () {
     setUp(() {
       MagicApp.reset();


### PR DESCRIPTION
## What

Adds an optional `pushProvisioned` parameter (default `true`, backward-compatible) to the notification preferences view. When `false`, the view surfaces an info hint telling the user push is not yet configured for the app.

Part of the notification-delivery phase-2 rollout: the uptizm backend now exposes `meta.push_provisioned` on the notification-channel index, and the uptizm client renders this hint when the app has no OneSignal `app_id` provisioned.

## Notes

- Additive and backward-compatible: existing callers see no change (default `true`).
- `flutter analyze`: No issues found.
- Independent of the profile locale wire-key fix (PR #81); cherry-picked onto `main` so the two concerns ship separately.

Client counterpart: anilcancakir/uptizm notification-delivery rollout.