### PR TITLE
fix(ui): the settings scaffold owned no page padding and ignored the host's width

### DIFF
--- a/lib/src/magic_starter_manager.dart
+++ b/lib/src/magic_starter_manager.dart
@@ -151,6 +151,23 @@ class MagicStarterManager {
   /// the sidebar, header, content background, drawer, and brand bar.
   MagicStarterLayoutTheme layoutTheme = const MagicStarterLayoutTheme();
 
+  /// The cap [MSSettingsScaffold] applies when the host configures nothing.
+  ///
+  /// Generous on purpose: a narrow centred strip leaves large empty gutters on
+  /// a desktop window, which is what this value was widened to avoid.
+  static const String defaultSettingsMaxWidth = 'max-w-7xl';
+
+  /// Wind max-width utility capping the Settings sub-page content column.
+  ///
+  /// A host app caps its own pages at its own width, and the settings pages
+  /// render inside that same shell. When this stayed at
+  /// [defaultSettingsMaxWidth] in an app whose pages cap narrower, both columns
+  /// centred inside the same content region but at different widths, so every
+  /// settings header started tens of pixels further out than every other page
+  /// (64px per side against a `max-w-6xl` host). Set it to the host's own page
+  /// width so the two line up.
+  String settingsMaxWidthClassName = defaultSettingsMaxWidth;
+
   /// Get the unified theme built from all individual sub-theme fields.
   ///
   /// Reading this constructs a [MagicStarterTheme] from the current values of

--- a/lib/src/ui/components/settings_scaffold/settings_scaffold.dart
+++ b/lib/src/ui/components/settings_scaffold/settings_scaffold.dart
@@ -12,9 +12,18 @@ import 'settings_scaffold.recipe.dart';
 /// affordance) and a `mt-6 flex flex-col gap-6` children area intended for
 /// [MSSettingsSection] widgets.
 ///
-/// Works identically on mobile and desktop inside `layout.app`: the inner
-/// column is always `w-full max-w-2xl mx-auto px-4 lg:px-0` so content is
-/// edge-padded on narrow screens and centred with no padding on wide ones.
+/// Works on mobile and desktop inside `layout.app` from one className: the inner
+/// column is `w-full px-4 lg:px-8 pt-6 sm:pt-8 pb-16 mx-auto` plus a max-width
+/// cap, so content is edge-padded on narrow screens, more generously padded from
+/// `lg`, and centred once it reaches the cap. The VERTICAL padding is this
+/// column's own: the app layout's content region is a bare scroll view, so
+/// without it the page header would touch the top edge of the viewport.
+///
+/// The cap is the HOST's to choose, through
+/// `MagicStarterManager.settingsMaxWidthClassName`. It has to match the width the
+/// host caps its own pages at, or these pages centre at a different width inside
+/// the same shell and every settings header starts further out than the header on
+/// every other page in the app.
 ///
 /// The [SingleChildScrollView] uses `primary: false` so it owns its own
 /// implicit scroll controller and never contends with the ambient

--- a/lib/src/ui/components/settings_scaffold/settings_scaffold.dart
+++ b/lib/src/ui/components/settings_scaffold/settings_scaffold.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:magic/magic.dart';
 
+import '../../../facades/magic_starter.dart';
 import '../page_header/page_header.dart';
 import 'settings_scaffold.recipe.dart';
 
@@ -91,7 +92,11 @@ class MSSettingsScaffold extends StatelessWidget {
       child: SingleChildScrollView(
         primary: false,
         child: WDiv(
-          className: settingsScaffoldContainerRecipe(),
+          // The cap comes from the host: these pages share the host's shell, so
+          // they have to share the width the host caps its own pages at.
+          className: settingsScaffoldContainerRecipe(
+            maxWidthClassName: MagicStarter.manager.settingsMaxWidthClassName,
+          ),
           children: [
             // 2. Unified page header — back affordance is composed here.
             MSPageHeader(

--- a/lib/src/ui/components/settings_scaffold/settings_scaffold.recipe.dart
+++ b/lib/src/ui/components/settings_scaffold/settings_scaffold.recipe.dart
@@ -23,15 +23,21 @@ String settingsScaffoldScrollableRecipe() {
 ///
 /// Mobile-first and fills the available content width like the other
 /// authenticated pages: `w-full` with comfortable edge padding (`px-4`, wider
-/// `lg:px-8` on desktop). No narrow centred max-width cap — a thin centred strip
-/// left large empty gutters on desktop. A very generous `max-w-7xl` cap only
-/// keeps rows from becoming absurdly wide on ultra-wide monitors.
+/// `lg:px-8` on desktop). [maxWidthClassName] carries the cap, which the host
+/// app owns (see `MagicStarterManager.settingsMaxWidthClassName`) because it has
+/// to match the width the host caps its own pages at.
 ///
-/// Emission order: base (width + padding + cap + mx-auto).
-String settingsScaffoldContainerRecipe() {
+/// The VERTICAL padding is this column's own responsibility. The app layout's
+/// content region is a bare scroll view with no padding, so a scaffold emitting
+/// no `pt-*` glued every settings header to the top edge of the viewport while
+/// every other page in the host sat a notch below it. `pb-16` keeps the last
+/// row from ending flush against the fold.
+///
+/// Emission order: base (width + padding + mx-auto) then the caller's cap.
+String settingsScaffoldContainerRecipe({required String maxWidthClassName}) {
   return const WindRecipe(
-    base: 'w-full px-4 lg:px-8 max-w-7xl mx-auto',
-  )();
+    base: 'w-full px-4 lg:px-8 pt-6 sm:pt-8 pb-16 mx-auto',
+  )(className: maxWidthClassName);
 }
 
 /// Returns the className for the children area (SettingsSections column).

--- a/test/ui/components/settings_scaffold/settings_scaffold_test.dart
+++ b/test/ui/components/settings_scaffold/settings_scaffold_test.dart
@@ -184,7 +184,8 @@ void main() {
     expect(childArea, isNotEmpty);
   });
 
-  testWidgets('SettingsScaffold outer container has the default cap and mx-auto',
+  testWidgets(
+      'SettingsScaffold outer container has the default cap and mx-auto',
       (tester) async {
     await tester.pumpWidget(
       wrap(

--- a/test/ui/components/settings_scaffold/settings_scaffold_test.dart
+++ b/test/ui/components/settings_scaffold/settings_scaffold_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:magic/magic.dart';
+import 'package:magic_starter/src/facades/magic_starter.dart';
 import 'package:magic_starter/src/magic_starter_manager.dart';
 import 'package:magic_starter/src/ui/components/settings_scaffold/settings_scaffold.dart';
 import 'package:magic_starter/src/ui/components/settings_scaffold/settings_scaffold.recipe.dart';
@@ -37,19 +38,45 @@ void main() {
       expect(cls, contains('w-full'));
     });
 
-    test('container recipe emits max-w-7xl token', () {
-      final cls = settingsScaffoldContainerRecipe();
-      expect(cls, contains('max-w-7xl'));
+    test('container recipe caps at the max width it is handed', () {
+      final cls = settingsScaffoldContainerRecipe(
+        maxWidthClassName: 'max-w-6xl',
+      );
+      expect(cls, contains('max-w-6xl'));
+      expect(cls, isNot(contains('max-w-7xl')));
     });
 
     test('container recipe emits mx-auto token', () {
-      final cls = settingsScaffoldContainerRecipe();
+      final cls = settingsScaffoldContainerRecipe(
+        maxWidthClassName: MagicStarterManager.defaultSettingsMaxWidth,
+      );
       expect(cls, contains('mx-auto'));
     });
 
     test('container recipe emits px-4 token', () {
-      final cls = settingsScaffoldContainerRecipe();
+      final cls = settingsScaffoldContainerRecipe(
+        maxWidthClassName: MagicStarterManager.defaultSettingsMaxWidth,
+      );
       expect(cls, contains('px-4'));
+    });
+
+    // A Settings sub-page owns its own top offset: the app layout's content
+    // region is a bare scroll view with no padding, so a scaffold with no
+    // `pt-*` glued every settings header to the top edge of the viewport while
+    // every other page in the host sat a comfortable notch below it.
+    test('container recipe emits the page top padding', () {
+      final cls = settingsScaffoldContainerRecipe(
+        maxWidthClassName: MagicStarterManager.defaultSettingsMaxWidth,
+      );
+      expect(cls, contains('pt-6'));
+      expect(cls, contains('sm:pt-8'));
+    });
+
+    test('container recipe emits a bottom padding', () {
+      final cls = settingsScaffoldContainerRecipe(
+        maxWidthClassName: MagicStarterManager.defaultSettingsMaxWidth,
+      );
+      expect(cls, contains('pb-16'));
     });
 
     test('children area recipe emits mt-6 token', () {
@@ -157,7 +184,7 @@ void main() {
     expect(childArea, isNotEmpty);
   });
 
-  testWidgets('SettingsScaffold outer container has max-w-7xl and mx-auto',
+  testWidgets('SettingsScaffold outer container has the default cap and mx-auto',
       (tester) async {
     await tester.pumpWidget(
       wrap(
@@ -172,9 +199,36 @@ void main() {
         .widgetList<WDiv>(find.byType(WDiv))
         .where(
           (w) =>
-              w.className?.contains('max-w-7xl') == true &&
+              w.className?.contains(
+                    MagicStarterManager.defaultSettingsMaxWidth,
+                  ) ==
+                  true &&
               w.className?.contains('mx-auto') == true,
         )
+        .toList();
+    expect(constrainedDivs, isNotEmpty);
+  });
+
+  // A host app caps its own pages at its own width. When the scaffold ignored
+  // that and always capped at its default, every settings header started tens
+  // of pixels further out than every other page in the same app on a wide
+  // window: same sidebar, same chrome, two different content columns.
+  testWidgets('SettingsScaffold caps at the width the host configured',
+      (tester) async {
+    MagicStarter.manager.settingsMaxWidthClassName = 'max-w-6xl';
+
+    await tester.pumpWidget(
+      wrap(
+        const MSSettingsScaffold(
+          title: 'Profile',
+          children: [],
+        ),
+      ),
+    );
+
+    final constrainedDivs = tester
+        .widgetList<WDiv>(find.byType(WDiv))
+        .where((w) => w.className?.contains('max-w-6xl') == true)
         .toList();
     expect(constrainedDivs, isNotEmpty);
   });


### PR DESCRIPTION
## What was wrong

Two halves of the same mismatch, both found by comparing the settings pages against the host app's own pages at a 1800px viewport.

**No vertical padding.** The app layout's content region is a bare scroll view with no padding of its own, so the settings column's `pt-*` is the only thing between the page header and the top edge of the viewport. `settingsScaffoldContainerRecipe` emitted none, so every settings page sat 32px higher than every other page in the same shell. Measured live in uptizm: title top at 23px against 55px everywhere else.

**A cap the host cannot influence.** The scaffold always capped at `max-w-7xl` while a host caps its own pages wherever it likes. Both columns then centred inside the same content region at different widths, and the settings header started 64px further out per side than the header on every other page: same sidebar, same chrome, two content columns.

## What changed

- `settingsScaffoldContainerRecipe` now emits `pt-6 sm:pt-8 pb-16` and takes the cap as a required `maxWidthClassName`.
- `MagicStarterManager.settingsMaxWidthClassName` carries that cap, defaulting to `defaultSettingsMaxWidth` (`max-w-7xl`, the value the scaffold has always used), so **an app that configures nothing sees no change in width**. Only the vertical padding is new for existing consumers, and it is a strict improvement: the header was touching the viewport edge.
- `MSSettingsScaffold` reads the field. `MagicStarter.manager` has a shared fallback manager, so this is safe in previews and in tests that do not bind the container.

One commit because the recipe parameter is required: the manager field, the widget call site and the guards have to land together or the package does not compile.

## Verification

- Recipe guards for the padding tokens and for a caller-supplied cap; a widget test proving a host override reaches the rendered className.
- Full suite: **1265 tests pass**. `flutter analyze`: clean.
- Verified live in uptizm, which sets the field to its own `max-w-6xl`: content column now identical across dashboard, monitors and settings (left 468, right 1555 on all three), content top 55/55/54. Checked on production at `app.uptizm.com`, not only locally.