### PR TITLE
chore(release): magic_starter 0.0.1-alpha.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.0.1-alpha.19] - 2026-08-03
+
 ### Added
 
 - **`MSPageContainer`: one page container for every page, in this package and in the host app.** The width cap the previous release handed to the host fixed the settings pages and nothing else, because the cap was only ever half the geometry and only one of three surfaces read it. The team pages (`/teams/create`, `/teams/settings`) and the notification pages (`/notifications`, `/notifications/preferences`) opened with a bare `WDiv(className: 'p-4 lg:p-6 flex flex-col gap-6')`: no cap at all, so on a desktop window they spread the full width of the content region while the settings and host pages centred in a column, and `p-4 lg:p-6` against the settings scaffold's `px-4 lg:px-8` put their headers on a different vertical and horizontal grid. Three surfaces, three answers, one shell. `MSPageContainer` now owns the geometry (width, edge margins, vertical rhythm, plus a horizontal safe-area guard so content never slides under a rounded display corner), `MSPageScaffold` composes it, and a host app uses the same component for its own pages. Nothing per page is left to disagree about.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: magic_starter
 description: Starter kit for Magic Framework. Auth, Profile, Teams, Notifications — 13 opt-in features with overridable views.
-version: 0.0.1-alpha.18
+version: 0.0.1-alpha.19
 homepage: https://magic.fluttersdk.com/starter
 documentation: https://magic.fluttersdk.com/packages/starter/getting-started/installation
 repository: https://github.com/fluttersdk/magic_starter


### PR DESCRIPTION
Cuts `0.0.1-alpha.19` from the work merged in #89: the `[Unreleased]` block moves
under a dated heading and `pubspec.yaml` bumps.

## What ships

`MSPageContainer`, one page container for every page in this package and in the
host app, with the geometry owned by the host through
`MagicStarterManager.pageContainerClassName`. `MSSettingsScaffold` becomes
`MSPageScaffold` and composes it. Five views (Notifications, Notification
Preferences, Team Create, Team Settings, Profile Settings) move onto that shared
chrome. All six pre-`MS`-prefix alias widgets are removed.

## Breaking changes for a consumer

| Before | After |
|---|---|
| `MagicStarterManager.settingsMaxWidthClassName` | `pageContainerClassName`, now the whole geometry (a cap-only value still works) |
| `MSSettingsScaffold` | `MSPageScaffold` |
| `settingsScaffoldScrollableRecipe()` | `pageScaffoldSurfaceRecipe()` |
| `settingsScaffoldChildrenAreaRecipe()` | `pageScaffoldChildrenAreaRecipe()` |
| `settingsScaffoldContainerRecipe()` | removed; render `MSPageContainer` or call `pageContainerRecipe()` |
| `MagicStarterCard`, `MagicStarterPageHeader`, `MagicStarterSocialDivider`, `MagicStarterNotificationDropdown`, `MagicStarterTeamSelector`, `MagicStarterUserProfileDropdown` | their `MS*` counterparts |

An app that configures nothing sees no visual change:
`defaultPageContainerClassName` reproduces the previous scaffold geometry exactly.

`MagicStarterTimezoneSelect` is untouched and keeps its name.

## Verification

`flutter analyze` clean, `dart format` clean, 1249 tests green on the merged main.
The full rationale, the live cross-page measurements, and the migration notes are
in #89.

Tag `0.0.1-alpha.19` after merge to trigger `publish.yml`.
