### PR TITLE
Document the page header's inline mode, which the last change skipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`MSPageHeader`'s inline mode is settable from the theme, so its two halves cannot drift apart.** `inlineActions` does two things at once: it swaps `containerClassName` for `containerInlineClassName`, and it gives the title row `flex-1 min-w-0` instead of only `sm:flex-1`. Those are two halves of one decision, and until now a consumer could set the first and not the second, because the container class is a theme string while the flex behaviour was a widget argument. That combination silently overflows: an app that themes the container into a row at every width, so a phone header keeps its action beside the title rather than dropping it under the subtitle, leaves the title row without `flex-1` below `sm`. The title column is `flex-initial`, a loose fit, so the text takes its intrinsic width and runs past the actions. Measured in a host app at 40 logical pixels on a 390px viewport with a two-word title and three icon buttons, and reproduced in the suite at 79. `line-clamp-2` on the title cannot save it, for the same reason `truncate` cannot without a constrained box. `MSPageScaffold` does not forward `inlineActions` at all, so a scaffold consumer had no way to reach the second half even knowing it existed; the flag now lives on `MagicStarterPageHeaderTheme`, beside the container class that requires it.
+
+### Changed
+
+- **`MSPageHeader.inlineActions` is now `bool?` and falls back to `MagicStarterPageHeaderTheme.inlineActions`.** Not breaking: the theme field defaults to `false`, which is the previous behaviour, and an explicit argument still beats the theme, so every existing caller is unchanged.
+
 ## [0.0.1-alpha.19] - 2026-08-03
 
 ### Added

--- a/doc/architecture/manager.md
+++ b/doc/architecture/manager.md
@@ -423,7 +423,7 @@ MagicStarter.useCardTheme(
 <a name="page-header-theme"></a>
 ## Page Header Theme
 
-`MagicStarterPageHeaderTheme` overrides Wind UI tokens for the `MSPageHeader` container, title, subtitle, and action container.
+`MagicStarterPageHeaderTheme` overrides Wind UI tokens for the `MSPageHeader` container, title, subtitle, and action container, plus one layout switch.
 
 ```dart
 MagicStarter.usePageHeaderTheme(
@@ -432,6 +432,34 @@ MagicStarter.usePageHeaderTheme(
   ),
 );
 ```
+
+### `inlineActions`, and the one combination that overflows
+
+The header stacks below `sm` and lays out as a row above it. An app that wants a
+row at EVERY width, so a phone header keeps its action beside the title instead
+of dropping it under the subtitle, overrides `containerClassName`:
+
+```dart
+MagicStarter.usePageHeaderTheme(
+  const MagicStarterPageHeaderTheme(
+    containerClassName: 'w-full flex flex-row items-start justify-between gap-3 ...',
+    // Required with the override above, and easy to miss.
+    inlineActions: true,
+  ),
+);
+```
+
+**Setting the container alone overflows.** `inlineActions` does two things: it
+selects `containerInlineClassName`, and it gives the title row `flex-1 min-w-0`
+instead of `sm:flex-1`. Without the second half the title column is
+`flex-initial`, a loose fit, so a long title takes its intrinsic width and runs
+past the actions rather than shrinking. `line-clamp-2` on the title does not
+help, for the same reason `truncate` does not without a constrained box.
+
+`MSPageHeader.inlineActions` is `bool?` and defaults to this field, so a single
+screen can still opt out with `inlineActions: false`. `MSPageScaffold` does not
+expose the argument, which is why the theme is the only reachable switch for a
+scaffold consumer.
 
 <a name="layout-theme"></a>
 ## Layout Theme

--- a/doc/basics/components.md
+++ b/doc/basics/components.md
@@ -175,7 +175,7 @@ The `.recipe.dart` file contains a top-level function (e.g. `buttonRecipe`, `car
 |-----------|-------|
 | `MSFormField` | Label + input + hint + error layout wrapper |
 | `MSCard` | Surface/inset/elevated variants |
-| `MSPageHeader` | Full-width responsive header (title, subtitle, leading, actions) |
+| `MSPageHeader` | Full-width responsive header (title, subtitle, leading, actions). Stacked below `sm`, a row above it; `inlineActions` (or `MagicStarterPageHeaderTheme.inlineActions`) makes it a row at every width AND lets a long title shrink instead of overflowing |
 | `MSSocialDivider` | "Or continue with" separator for auth forms |
 | `MSNotificationDropdown` | Bell-icon dropdown with a live unread badge, backed by a notification stream |
 | `MSUserProfileDropdown` | Avatar menu with profile links, theme toggle and logout |


### PR DESCRIPTION
Follow-up to #92, which shipped the code and none of the paper. `CLAUDE.md` has a post-change checklist and I ran none of it.

> **Post-Change Checklist.** After ANY source code change, sync **before committing**:
> 1. `CHANGELOG.md` — Add entry under `[Unreleased]`
> 2. `README.md` — Update if features, API, or usage changes
> 3. `doc/` — Update relevant documentation files

For an unreleased package that would be untidy. For a published one it is half the change: the field is reachable and nothing tells anybody it exists or what it prevents.

## What is here

**`CHANGELOG.md`** under `[Unreleased]`, split Fixed / Changed. It carries the measurement rather than only the fix: the combination that overflows is a theme override plus the missing flag, seen at 40 logical pixels in a host app and reproduced at 79 in the suite. The `Changed` half states plainly that `bool?` is not breaking, because that is the first question a reader will have.

**`doc/architecture/manager.md`** gains the case worth documenting, which is not "here is a new field" but "setting the container alone overflows". Anybody overriding `containerClassName` into a row is one paragraph away from the bug, so the paragraph sits under the override, with the two-line snippet that gets it right.

**`doc/basics/components.md`** gains one clause on its summary line: the header stacks below `sm`, and what turns that off.

## What is deliberately not here

**README.** Its component table is a name and a phrase per widget, and the header's entry is still accurate. Putting the inline caveat there would be the third copy of it. The checklist says "update if features, API, or usage changes", and the usage that changed is documented where usage lives.

## One honest note on process

`CLAUDE.md` asks for red-green-refactor, and #92 went code-first: I wrote the fix, then the tests, then proved them red by reverting the fix. The property that matters held (`A RenderFlex overflowed by 79 pixels on the right` is what the test reports without the fix, so it fails for the reason it claims) but the order was wrong, and saying so is cheaper than implying otherwise.

## Verification

`dart format --set-exit-if-changed .` clean, `dart analyze` clean, 1253 tests pass. No source change in this PR.