### PR TITLE
magic_starter 0.0.1-alpha.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.0.1-alpha.20] - 2026-08-17
+
 ### Fixed
 
 - **`MSPageHeader`'s inline mode is settable from the theme, so its two halves cannot drift apart.** `inlineActions` does two things at once: it swaps `containerClassName` for `containerInlineClassName`, and it gives the title row `flex-1 min-w-0` instead of only `sm:flex-1`. Those are two halves of one decision, and until now a consumer could set the first and not the second, because the container class is a theme string while the flex behaviour was a widget argument. That combination silently overflows: an app that themes the container into a row at every width, so a phone header keeps its action beside the title rather than dropping it under the subtitle, leaves the title row without `flex-1` below `sm`. The title column is `flex-initial`, a loose fit, so the text takes its intrinsic width and runs past the actions. Measured in a host app at 40 logical pixels on a 390px viewport with a two-word title and three icon buttons, and reproduced in the suite at 79. `line-clamp-2` on the title cannot save it, for the same reason `truncate` cannot without a constrained box. `MSPageScaffold` does not forward `inlineActions` at all, so a scaffold consumer had no way to reach the second half even knowing it existed; the flag now lives on `MagicStarterPageHeaderTheme`, beside the container class that requires it.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: magic_starter
 description: Starter kit for Magic Framework. Auth, Profile, Teams, Notifications — 13 opt-in features with overridable views.
-version: 0.0.1-alpha.19
+version: 0.0.1-alpha.20
 homepage: https://magic.fluttersdk.com/starter
 documentation: https://magic.fluttersdk.com/packages/starter/getting-started/installation
 repository: https://github.com/fluttersdk/magic_starter


### PR DESCRIPTION
Version bump and changelog date. Two files, matching #90's shape.

## What ships

Exactly two commits since `0.0.1-alpha.19`, both about one defect:

- **#92** — `MSPageHeader`'s inline mode is settable from the theme, so its two halves cannot drift apart.
- **#93** — the docs and CHANGELOG that #92 skipped.

Nothing else is in `[Unreleased]`, so this release is the header fix and its paper, and nothing rides along.

## Why it is worth a release rather than waiting

`inlineActions` does two things at once: it selects `containerInlineClassName`, and it gives the title row `flex-1 min-w-0` instead of `sm:flex-1`. The container class is a theme string and the flex behaviour was a widget argument, so a consumer could set the first and not the second, and that combination silently overflows. `MSPageScaffold` does not forward the argument at all, so a scaffold consumer could not reach the second half even knowing it existed.

The consumer that hit it is depools, whose product screen reports `A RenderFlex overflowed by 40 pixels on the right` at 390 today. It cannot take the fix until this is on pub.dev: it pins `^0.0.1-alpha.17`, and the field does not exist in `alpha.19`.

## Not breaking

`MSPageHeader.inlineActions` became `bool?` falling back to a theme field that defaults to `false`, which is the previous behaviour, and an explicit argument still wins. Every existing caller is unchanged.

## Verification

`dart pub publish --dry-run` clean apart from the two files this PR is about (they read as modified until it is committed) and the standing `pubspec_overrides.yaml` hints, which are the workspace's local sibling paths and are gitignored, so CI resolves the hosted versions instead.

`dart format --set-exit-if-changed .` clean, `dart analyze` clean, **1253 tests pass**. The overflow is one of them: reverting the title-row half reports `A RenderFlex overflowed by 79 pixels on the right`.

## After merge

`git tag 0.0.1-alpha.20 && git push --tags` fires `publish.yml`, which is the trigger this repo uses.

## One thing noticed and left alone

`CLAUDE.md`'s banner still reads `**Version:** 0.0.1-alpha.14`, six releases behind. Previous release PRs did not touch it either, so it is clearly not part of this ritual, and correcting it inside a release PR would add review surface with no release value. Worth its own one-line PR.