### PR TITLE
fix(profile): apply a saved language to the running app

### DIFF
--- a/lib/src/http/controllers/magic_starter_profile_controller.dart
+++ b/lib/src/http/controllers/magic_starter_profile_controller.dart
@@ -93,6 +93,7 @@ class MagicStarterProfileController extends MagicController
 
       await Auth.restore();
       Magic.toast(trans('profile.updated'));
+      _applySavedLanguage(language);
       setSuccess(true);
       return true;
     } catch (e, stackTrace) {
@@ -103,6 +104,35 @@ class MagicStarterProfileController extends MagicController
     } finally {
       _isSubmitting = false;
     }
+  }
+
+  /// Re-point the running app at a language the profile just saved.
+  ///
+  /// Saving a locale persisted it and confirmed it, and then the app went on
+  /// speaking the old language until its next boot. Five views pass `language`
+  /// to [doUpdateProfile], so this belongs here rather than in each of them.
+  ///
+  /// Scheduled after the current frame ON PURPOSE. [Lang.setLocale] loads the
+  /// catalogue and calls `Magic.reload()`, which swaps a key above the whole tree
+  /// and UNMOUNTS the view that is still inside its own `await` on this method.
+  /// The language page, for one, clears an isolated save spinner in a `finally`
+  /// on a `ValueNotifier` its own state owns and disposes; rebuilding before that
+  /// runs would use it after disposal. Letting the caller finish first costs one
+  /// frame and keeps every call site correct without any of them knowing.
+  ///
+  /// A no-op when the language is absent or already current, so re-saving a
+  /// profile without touching the selector does not flash a rebuild.
+  void _applySavedLanguage(String? language) {
+    if (language == null || language.isEmpty) return;
+    if (language == Lang.current.languageCode) return;
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      Lang.setLocale(Locale(language));
+    });
+    // `addPostFrameCallback` does not ASK for a frame, and an idle app stops
+    // producing them, so without this the switch could sit unapplied until the
+    // next interaction happened to schedule one.
+    WidgetsBinding.instance.scheduleFrame();
   }
 
   /// Update password.

--- a/test/http/controllers/magic_starter_profile_controller_test.dart
+++ b/test/http/controllers/magic_starter_profile_controller_test.dart
@@ -1,4 +1,7 @@
+import 'dart:ui' show Locale;
+
 import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart' show SizedBox;
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:magic/magic.dart';
@@ -281,6 +284,63 @@ void main() {
           mockDriver.lastData,
           equals({'name': 'Alice Updated', 'email': 'alice@example.com'}),
         );
+      });
+
+      testWidgets(
+        'a saved language is applied to the running app, not only persisted',
+        (tester) async {
+          // Saving a locale persisted it and confirmed it, and the app kept
+          // speaking the old language until its next boot: nothing re-pointed
+          // the translator after `Auth.restore()`.
+          await tester.pumpWidget(const SizedBox.shrink());
+          Translator.instance.setLoader(_StubLangLoader());
+          await Translator.instance.setLocale(const Locale('en'));
+          expect(Lang.current.languageCode, equals('en'));
+
+          mockDriver.mockResponse(
+            statusCode: 200,
+            data: {'message': 'Profile updated'},
+          );
+
+          final result = await controller.doUpdateProfile(
+            name: 'Alice',
+            email: 'alice@example.com',
+            language: 'tr',
+          );
+
+          expect(result, isTrue);
+          // Applied after the current frame on purpose: `Lang.setLocale` calls
+          // `Magic.reload()`, which unmounts the caller mid-await. The
+          // controller asks for that frame itself, so one pump runs it and the
+          // settle finishes the catalogue load it starts.
+          await tester.pump();
+          await tester.pumpAndSettle();
+
+          expect(Lang.current.languageCode, equals('tr'));
+        },
+      );
+
+      testWidgets('re-saving the same language does not switch anything', (
+        tester,
+      ) async {
+        await tester.pumpWidget(const SizedBox.shrink());
+        Translator.instance.setLoader(_StubLangLoader());
+        await Translator.instance.setLocale(const Locale('en'));
+
+        mockDriver.mockResponse(
+          statusCode: 200,
+          data: {'message': 'Profile updated'},
+        );
+
+        await controller.doUpdateProfile(
+          name: 'Alice',
+          email: 'alice@example.com',
+          language: 'en',
+        );
+        await tester.pump();
+        await tester.pumpAndSettle();
+
+        expect(Lang.current.languageCode, equals('en'));
       });
 
       test('failure (422) — returns false and sets error state', () async {
@@ -1149,4 +1209,11 @@ void main() {
       });
     });
   });
+}
+
+/// Serves an empty catalogue for any locale, so a locale switch in these tests
+/// succeeds without shipping copy for it.
+class _StubLangLoader implements TranslationLoader {
+  @override
+  Future<Map<String, dynamic>> load(Locale locale) async => <String, dynamic>{};
 }


### PR DESCRIPTION
## What

Saving a locale persisted it and confirmed it with a toast, and then the app went on speaking the old language until its next boot. Nothing re-pointed the translator after `Auth.restore()`, so `/settings/language`, the one screen whose entire purpose is changing the language, appeared to do nothing.

`doUpdateProfile` now applies it through `Lang.setLocale`, which loads the catalogue and rebuilds the tree.

## Why here and not in the views

Five call sites pass `language` to this method:

- `magic_starter_language_view.dart:79`
- `magic_starter_profile_settings_view.dart:196` and `:1372`
- `magic_starter_profile_sub_page_view.dart:433` and `:537`

Duplicating the application five times would guarantee one of them drifts.

## Two details that are load-bearing

**It is scheduled after the current frame.** `Lang.setLocale` calls `Magic.reload()` -> `MagicAppWidget.restart()`, which swaps a `UniqueKey` above the whole tree and therefore unmounts the caller that is still inside its own `await` on this method. The language page clears an isolated save spinner in a `finally`, on a `ValueNotifier` its own state owns and disposes, so rebuilding before that runs would use it after disposal. Letting the caller finish costs one frame and keeps every call site correct without any of them knowing.

**It asks for that frame explicitly.** `addPostFrameCallback` does not request a frame, and an idle Flutter app stops producing them, so without `scheduleFrame()` the switch could sit unapplied until the next interaction happened to schedule one. That is not a guess:

```
registered, fired=0
after pump 1: 0
after scheduleFrame + pump: 1
```

A no-op when the language is absent or already current, so re-saving a profile without touching the selector does not flash a rebuild.

## Testing

Two `testWidgets` cases in `magic_starter_profile_controller_test.dart`: a changed language switches `Lang.current`, an unchanged one does not. The first was confirmed to fail with the call removed.

`flutter test`: 1255 passing. `flutter analyze --no-fatal-infos`: clean. `dart format .`: applied.

Also verified end to end in a consuming app (uptizm, which resolves this package by path). Tapping Save on `/settings/language` with Türkçe selected, **with no reload**, turned the page title "Language" into "Dil", "Save" into "Kaydet" and the bottom tab bar into "Ana Sayfa / İzleyiciler / Olaylar / Durum". Before this change the same tap left every one of them in English.