### PR TITLE
fix(notifications): stop a preference row overflowing at a phone width

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -3,3 +3,11 @@ include: package:flutter_lints/flutter.yaml
 analyzer:
   errors:
     unintended_html_in_doc_comment: ignore
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**

--- a/lib/src/ui/views/notifications/magic_starter_notification_preferences_view.dart
+++ b/lib/src/ui/views/notifications/magic_starter_notification_preferences_view.dart
@@ -183,7 +183,14 @@ class _MagicStarterNotificationPreferencesViewState
       ''',
       children: [
         WDiv(
-          className: 'flex items-center gap-4',
+          // `flex-1 min-w-0` so the icon-plus-text half yields to the switch
+          // instead of demanding its intrinsic width. Without it the row
+          // overflowed by 14 pixels at 430px on any channel carrying the push
+          // hint below (measured in the uptizm app: Flutter painted the "RIGHT
+          // OVERFLOWED BY 14 PIXELS" stripe over every Push row), because a
+          // two-line text column is wider than a one-line one and nothing told
+          // it to shrink.
+          className: 'flex-1 min-w-0 flex items-center gap-4',
           children: [
             WDiv(
               className: '''
@@ -199,7 +206,9 @@ class _MagicStarterNotificationPreferencesViewState
               ),
             ),
             WDiv(
-              className: 'flex flex-col gap-1',
+              // `min-w-0` so the label and the hint can wrap rather than force
+              // the row wider than its container.
+              className: 'flex-1 min-w-0 flex flex-col gap-1',
               children: [
                 // The switch below carries this same text as its semanticLabel,
                 // so exclude the visible copy from semantics: otherwise the row

--- a/test/ui/views/notifications/magic_starter_notification_preferences_view_test.dart
+++ b/test/ui/views/notifications/magic_starter_notification_preferences_view_test.dart
@@ -154,6 +154,65 @@ void main() {
       expect(find.byType(MSSwitch), findsNWidgets(2));
     });
 
+    testWidgets('a push row with its hint fits a phone width', (tester) async {
+      // Every other case in this file runs at 1280 or 1920, which is why this
+      // never showed: the row overflowed by 14 pixels at 430px on any channel
+      // carrying the push hint, and Flutter painted its yellow-and-black stripe
+      // across it. Measured in the uptizm app before the fix.
+      tester.view.physicalSize = const Size(430, 900);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+
+      final matrix = {
+        'incident_opened': {
+          'label': 'Incident opened',
+          'channels': {
+            'mail': {'enabled': true, 'locked': false},
+            'push': {'enabled': true, 'locked': false},
+          }
+        }
+      };
+      mockDriver.mockResponse(statusCode: 200, data: {'data': matrix});
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: WindTheme(
+            data: WindThemeData(),
+            child: MediaQuery(
+              data: const MediaQueryData(size: Size(430, 900)),
+              child: const Scaffold(
+                body: SizedBox(
+                  width: 430,
+                  height: 900,
+                  child: SingleChildScrollView(
+                    child: MagicStarterNotificationPreferencesView(
+                      pushProvisioned: false,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // The hint is what makes the row two lines tall, so its presence is what
+      // makes this case the right one.
+      expect(
+        find.text(trans('notifications.channel_push_unconfigured')),
+        findsOneWidget,
+      );
+      expect(
+        tester.takeException(),
+        isNull,
+        reason: 'the preference row must not overflow at a phone width',
+      );
+    });
+
     testWidgets('locked channel checkbox is disabled', (tester) async {
       // Widen the test surface so untranslated trans() keys fit without overflow.
       tester.view.physicalSize = const Size(1920, 1080);


### PR DESCRIPTION
## What

The icon-plus-text half of a notification-preference row demanded its intrinsic
width, so any channel carrying the push hint underneath its label pushed the row
wider than its container. Measured at 430px in a consuming app (uptizm), Flutter
painted **"RIGHT OVERFLOWED BY 14 PIXELS"** across every Push row.

`flex-1 min-w-0` on both the half and the text column lets the label and the hint
wrap, and leaves the switch its own space.

## Why it was invisible

Every existing case in `magic_starter_notification_preferences_view_test.dart`
runs at 1280 or 1920, two of them widening the surface further with a comment
saying they do it so untranslated keys fit. So the row was only ever laid out
where it had room to spare.

The new case runs at 430 with `pushProvisioned: false`, so the hint is present and
the row is two lines tall. Without the fix it fails with a 267-pixel overflow; the
number is larger than the app's 14 because the test font is wider than the shipped
one, which is also why the assertion is "no exception" rather than a pixel count.

## Testing

`flutter test`: 1256 pass. `dart format` clean, `flutter analyze` clean.

---

## Correction, added after merge

This PR also carried an `analysis_options.yaml` change that its description never
mentioned: an `analyzer.exclude` block for `build/**` and the six platform
directories. It had been sitting uncommitted in my working tree across several
sessions and a `git add -A` swept it in.

The content is wanted (it is the same block going into uptizm as its own PR), so
it is not being reverted, but the record should say what actually landed. Measured
in the sibling repo: the block changes nothing today, since the platform
directories hold zero Dart files and the analyzer already leaves `build/` alone.
It is a guard for the first time that stops being true.

The preventable part was the staging. Explicit paths from here, not `-A`.