### PR TITLE
chore: clear the analyzer info debt, make infos fatal, and correct four stale docs

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -69,7 +69,7 @@ Check these files for any content that needs updating:
 Run all checks locally. ALL must pass before proceeding:
 
 1. `dart format --set-exit-if-changed .` — must be clean
-2. `dart analyze --no-fatal-infos` — must be zero issues
+2. `dart analyze` — must be zero issues (infos included; CI treats them as fatal)
 3. `flutter test` — must all pass
 4. `dart pub publish --dry-run` — must be zero warnings
 5. Review all changed files with `git diff`

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,7 +11,7 @@
           },
           {
             "type": "command",
-            "command": "jq -r '.tool_response.filePath // .tool_input.file_path' | grep '.dart$' && dart analyze --no-fatal-infos || true",
+            "command": "jq -r '.tool_response.filePath // .tool_input.file_path' | grep '.dart$' && dart analyze || true",
             "timeout": 15000
           }
         ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Analyze code
         working-directory: magic_starter
-        run: flutter analyze --no-fatal-infos
+        run: flutter analyze
 
       - name: Check formatting
         working-directory: magic_starter
@@ -126,4 +126,4 @@ jobs:
       # package's own source compiles against the sibling versions that are
       # actually released, which is where an unreleased API surfaces.
       - name: Analyze against the published siblings
-        run: flutter analyze --no-fatal-infos
+        run: flutter analyze

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
         run: flutter pub get
 
       - name: Analyze code
-        run: flutter analyze --no-fatal-infos
+        run: flutter analyze
 
       - name: Check formatting
         run: dart format --set-exit-if-changed .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to this project will be documented in this file.
 
 - **`MagicStarterBillingCycle` is gone; use `BillingCycle` from `magic_payments`.** Two enums for one concept is how the display copy and the charge drifted apart in the first place, so the wire type is now the only one. Same two members, same names, so the change at a call site is the import, and this barrel re-exports `BillingCycle` so that import is `package:magic_starter/magic_starter.dart` rather than a new dependency on an unpublished package. It had no callers outside this package's own billing view.
 
+### Changed
+
+- **Analyzer infos are fatal in CI now, and 44 of them were cleared first.** `flutter analyze --no-fatal-infos` is why 20 files could carry `use_null_aware_elements` and `unnecessary_underscores` findings with nothing going red. The findings are gone (applied by `dart fix`, so `if (x != null) x!` inside a collection literal is `?x` and `(_, __, ___)` is `(_, _, _)`, both well inside the `sdk: >=3.11.0` floor and neither changing behaviour, with the suite at the same 1394 on both sides), and the flag is gone with them from all three CI call sites plus the local post-edit hook and the release checklist, so a contributor cannot pass one gate and fail another. **The cost is worth knowing before you hit it:** a Dart SDK upgrade that ships a new lint now turns CI red with no code change. That is the trade, and the alternative is the debt this entry is clearing. (`.github/workflows/{ci,publish}.yml`, `.claude/settings.json`, `.claude/commands/release.md`, `CLAUDE.md`, 20 files under `lib/` and `test/`)
+
 ### Fixed
 
 - **The "Recommended" badge was drawn on top of the plan name.** It sat `absolute -top-2.5 left-5` inside a `relative` card, which is the CSS idiom for a badge straddling a border and did not survive the port: it landed over the heading, so "Recommended" and "Pro" were rendered on top of each other. It is IN FLOW now, on the name's row, `flex-1` on the name and `shrink-0` on the badge. It cannot collide at any width and needs no negative offset to sit where it belongs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Flutter starter kit for the Magic Framework. Pre-built Auth, Profile, Teams & No
 | `flutter test --coverage` | Run all tests (107 files, ~1394 cases) with coverage |
 | `flutter test test/http/controllers/` | Run controller tests only |
 | `flutter test --name "pattern"` | Run tests matching pattern |
-| `flutter analyze --no-fatal-infos` | Static analysis (flutter_lints ^6.0) |
+| `flutter analyze` | Static analysis (flutter_lints ^6.0). Infos are fatal in CI, so a new lint is fixed rather than filed. |
 | `dart format .` | Format all code |
 | `dart fix --apply` | Auto-fix lint issues |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 Flutter starter kit for the Magic Framework. Pre-built Auth, Profile, Teams & Notifications — 13 opt-in features, every screen overridable via Wind UI.
 
-**Version:** 0.0.1-alpha.14 · **Dart:** >=3.6.0 · **Flutter:** >=3.27.0
+**Version:** 0.0.1-alpha.20 · **Dart:** >=3.11.0 · **Flutter:** >=3.41.0
 
 ## Commands
 
@@ -12,7 +12,7 @@ Flutter starter kit for the Magic Framework. Pre-built Auth, Profile, Teams & No
 
 | Command | Description |
 |---------|-------------|
-| `flutter test --coverage` | Run all tests (~62 files, ~996 cases) with coverage |
+| `flutter test --coverage` | Run all tests (107 files, ~1394 cases) with coverage |
 | `flutter test test/http/controllers/` | Run controller tests only |
 | `flutter test --name "pattern"` | Run tests matching pattern |
 | `flutter analyze --no-fatal-infos` | Static analysis (flutter_lints ^6.0) |
@@ -35,7 +35,7 @@ Flutter starter kit for the Magic Framework. Pre-built Auth, Profile, Teams & No
 
 ```
 lib/
-├── magic_starter.dart              # Barrel export — 47 exports
+├── magic_starter.dart              # Barrel export — 91 exports
 ├── config/
 │   └── magic_starter.dart          # Configuration template stub
 └── src/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,4 +139,4 @@ Every feature, fix, or refactor must go through the red-green-refactor cycle:
 
 ## CI
 
-- `ci.yml`: push/PR → `flutter pub get` → `flutter analyze --no-fatal-infos` → `dart format --set-exit-if-changed` → `flutter test --coverage` → codecov upload
+- `ci.yml`: push/PR → `flutter pub get` → `flutter analyze` → `dart format --set-exit-if-changed` → `flutter test --coverage` → codecov upload

--- a/lib/src/ui/components/dropdown_menu/dropdown_menu.dart
+++ b/lib/src/ui/components/dropdown_menu/dropdown_menu.dart
@@ -89,7 +89,7 @@ class MSDropdownMenu extends StatelessWidget {
       alignment: alignment,
       className: panelClassName,
       enableTriggerOnTap: true,
-      triggerBuilder: (_, __, ___) => child,
+      triggerBuilder: (_, _, _) => child,
       contentBuilder: (_, close) => _buildItems(close),
     );
   }

--- a/lib/src/ui/components/empty_state/empty_state.dart
+++ b/lib/src/ui/components/empty_state/empty_state.dart
@@ -55,7 +55,7 @@ class MSEmptyState extends StatelessWidget {
         if (description != null)
           WText(description!, className: emptyStateDescriptionClassName()),
         // 4. Optional action slot.
-        if (action != null) action!,
+        ?action,
       ],
     );
   }

--- a/lib/src/ui/components/error_state/error_state.dart
+++ b/lib/src/ui/components/error_state/error_state.dart
@@ -58,7 +58,7 @@ class MSErrorState extends StatelessWidget {
         if (description != null)
           WText(description!, className: errorStateDescriptionClassName()),
         // 4. Optional action slot.
-        if (action != null) action!,
+        ?action,
       ],
     );
   }

--- a/lib/src/ui/components/page_container/page_container.recipe.dart
+++ b/lib/src/ui/components/page_container/page_container.recipe.dart
@@ -20,7 +20,7 @@ import 'package:magic/magic.dart';
 String pageContainerRecipe({required String hostClassName, String? className}) {
   final Iterable<String> geometry = <String>[
     hostClassName,
-    if (className != null) className,
+    ?className,
   ].where((String segment) => segment.isNotEmpty);
 
   return const WindRecipe(base: 'w-full mx-auto')(

--- a/lib/src/ui/components/page_header/page_header.dart
+++ b/lib/src/ui/components/page_header/page_header.dart
@@ -158,7 +158,7 @@ class MSPageHeader extends StatelessWidget {
               ? 'flex flex-row items-center gap-3 flex-1 min-w-0'
               : 'flex flex-row items-center gap-3 sm:flex-1 min-w-0',
           children: [
-            if (effectiveLeading != null) effectiveLeading,
+            ?effectiveLeading,
             // The title column shrinks for truncation (flex-initial =
             // FlexFit.loose) but does NOT grow, so a `titleSuffix` sits right
             // after the title instead of being pushed to the row's far edge.

--- a/lib/src/ui/components/tooltip/tooltip.dart
+++ b/lib/src/ui/components/tooltip/tooltip.dart
@@ -60,7 +60,7 @@ class MSTooltip extends StatelessWidget {
       alignment: alignment,
       className: panelClassName,
       enableTriggerOnTap: true,
-      triggerBuilder: (_, __, ___) => child,
+      triggerBuilder: (_, _, _) => child,
       contentBuilder: (_, close) => content,
     );
   }

--- a/lib/src/ui/views/auth/magic_starter_login_view.dart
+++ b/lib/src/ui/views/auth/magic_starter_login_view.dart
@@ -103,7 +103,7 @@ class _MagicStarterLoginViewState
         child: WDiv(
           className: 'flex flex-col items-stretch',
           children: [
-            if (headerSlot != null) headerSlot,
+            ?headerSlot,
             _buildIdentityField(),
             const WSpacer(className: 'h-4'),
             WFormInput(
@@ -165,7 +165,7 @@ class _MagicStarterLoginViewState
                 ),
               ),
             ],
-            if (formFooterSlot != null) formFooterSlot,
+            ?formFooterSlot,
             if (MagicStarterConfig.hasSocialLoginFeatures() &&
                 MagicStarter.hasSocialLogin) ...[
               const MSSocialDivider(),
@@ -192,7 +192,7 @@ class _MagicStarterLoginViewState
                 ),
               ),
             ],
-            if (footerSlot != null) footerSlot,
+            ?footerSlot,
           ],
         ),
       ),

--- a/lib/src/ui/views/auth/magic_starter_register_view.dart
+++ b/lib/src/ui/views/auth/magic_starter_register_view.dart
@@ -106,7 +106,7 @@ class _MagicStarterRegisterViewState
         child: WDiv(
           className: 'flex flex-col items-stretch',
           children: [
-            if (headerSlot != null) headerSlot,
+            ?headerSlot,
 
             // Name
             WFormInput(
@@ -200,7 +200,7 @@ class _MagicStarterRegisterViewState
               ),
             ),
 
-            if (formFooterSlot != null) formFooterSlot,
+            ?formFooterSlot,
 
             // Social login slot
             if (MagicStarterConfig.hasSocialLoginFeatures() &&
@@ -228,7 +228,7 @@ class _MagicStarterRegisterViewState
                 ],
               ),
             ),
-            if (footerSlot != null) footerSlot,
+            ?footerSlot,
           ],
         ),
       ),

--- a/lib/src/ui/views/auth/magic_starter_two_factor_challenge_view.dart
+++ b/lib/src/ui/views/auth/magic_starter_two_factor_challenge_view.dart
@@ -91,7 +91,7 @@ class _MagicStarterTwoFactorChallengeViewState
       child: WDiv(
         className: 'flex flex-col gap-6',
         children: [
-          if (headerSlot != null) headerSlot,
+          ?headerSlot,
           // MSInput
           WFormInput(
             controller: _codeController,
@@ -128,7 +128,7 @@ class _MagicStarterTwoFactorChallengeViewState
               ),
             ],
           ),
-          if (footerSlot != null) footerSlot,
+          ?footerSlot,
         ],
       ),
     );

--- a/lib/src/ui/views/notifications/magic_starter_notification_preferences_view.dart
+++ b/lib/src/ui/views/notifications/magic_starter_notification_preferences_view.dart
@@ -81,11 +81,7 @@ class _MagicStarterNotificationPreferencesViewState
       subtitle: trans('notifications.preferences_description'),
       backLabel: trans('profile.settings'),
       backFallback: MagicStarterConfig.settingsHubRoute(),
-      children: [
-        if (headerSlot != null) headerSlot,
-        _buildMatrixSettings(),
-        if (footerSlot != null) footerSlot,
-      ],
+      children: [?headerSlot, _buildMatrixSettings(), ?footerSlot],
     );
   }
 

--- a/lib/src/ui/views/notifications/magic_starter_notifications_list_view.dart
+++ b/lib/src/ui/views/notifications/magic_starter_notifications_list_view.dart
@@ -125,9 +125,9 @@ class _MagicStarterNotificationsListViewState
       subtitle: trans('notifications.list_subtitle'),
       actions: _buildHeaderActions(hasUnread: hasUnread),
       children: [
-        if (headerSlot != null) headerSlot,
+        ?headerSlot,
         _buildBody(context, notifications, totalPages),
-        if (footerSlot != null) footerSlot,
+        ?footerSlot,
       ],
     );
   }

--- a/lib/src/ui/views/profile/magic_starter_profile_settings_view.dart
+++ b/lib/src/ui/views/profile/magic_starter_profile_settings_view.dart
@@ -442,10 +442,10 @@ class _MagicStarterProfileSettingsViewState
       title: trans('profile.settings'),
       subtitle: trans('profile.settings_subtitle'),
       children: [
-        if (headerSlot != null) headerSlot,
+        ?headerSlot,
         if (MagicStarterConfig.hasProfilePhotoFeatures() &&
             Gate.allows('starter.update-profile-photo')) ...[
-          if (beforePhotoSlot != null) beforePhotoSlot,
+          ?beforePhotoSlot,
           _buildProfilePhotoSection(),
         ],
         // Email verification banner right after photo when unverified.
@@ -454,9 +454,9 @@ class _MagicStarterProfileSettingsViewState
             !controller.isEmailVerified)
           _buildEmailVerificationSection(),
         MagicForm(formData: profileForm, child: _buildProfileSection()),
-        if (afterInfoSlot != null) afterInfoSlot,
+        ?afterInfoSlot,
         if (Gate.allows('starter.update-password')) ...[
-          if (beforePasswordSlot != null) beforePasswordSlot,
+          ?beforePasswordSlot,
           _buildPasswordSection(),
         ],
         // Verified badge shown inline (not at top).
@@ -473,10 +473,10 @@ class _MagicStarterProfileSettingsViewState
         if (Gate.denies('starter.delete-account')) _buildGuestUpgradeSection(),
         if (MagicStarterConfig.hasSessionsFeatures()) ...[
           _buildSessionsSection(),
-          if (afterSessionsSlot != null) afterSessionsSlot,
+          ?afterSessionsSlot,
         ],
         _buildDeleteAccountSection(),
-        if (footerSlot != null) footerSlot,
+        ?footerSlot,
       ],
     );
   }

--- a/lib/src/ui/views/profile/magic_starter_profile_sub_page_view.dart
+++ b/lib/src/ui/views/profile/magic_starter_profile_sub_page_view.dart
@@ -152,7 +152,7 @@ class _MagicStarterProfileSubPageViewState
       backLabel: trans('magic_starter.nav.settings'),
       backFallback: MagicStarterConfig.settingsHubRoute(),
       children: [
-        if (headerSlot != null) headerSlot,
+        ?headerSlot,
 
         // 1. Profile photo.
         if (MagicStarterConfig.hasProfilePhotoFeatures() &&
@@ -172,7 +172,7 @@ class _MagicStarterProfileSubPageViewState
         //    not here, to keep the Profile form clean.
         if (isGuest) _buildGuestUpgradeSection(),
 
-        if (footerSlot != null) footerSlot,
+        ?footerSlot,
       ],
     );
   }

--- a/lib/src/ui/views/settings/magic_starter_settings_hub_view.dart
+++ b/lib/src/ui/views/settings/magic_starter_settings_hub_view.dart
@@ -198,7 +198,7 @@ class _MagicStarterSettingsHubViewState
     return MSPageScaffold(
       title: trans('magic_starter.nav.settings'),
       children: [
-        if (headerSlot != null) headerSlot,
+        ?headerSlot,
         if (accountRows.isNotEmpty)
           MSSettingsSection(
             header: trans('magic_starter.settings.account_section'),
@@ -214,7 +214,7 @@ class _MagicStarterSettingsHubViewState
             header: trans('magic_starter.settings.preferences_section'),
             children: preferencesRows,
           ),
-        if (footerSlot != null) footerSlot,
+        ?footerSlot,
       ],
     );
   }

--- a/lib/src/ui/views/teams/magic_starter_team_create_view.dart
+++ b/lib/src/ui/views/teams/magic_starter_team_create_view.dart
@@ -60,11 +60,7 @@ class _MagicStarterTeamCreateViewState
       subtitle: trans('teams.create_team_subtitle'),
       backLabel: trans('teams.settings'),
       backFallback: MagicStarterConfig.teamSettingsRoute(),
-      children: [
-        if (headerSlot != null) headerSlot,
-        _buildForm(),
-        if (footerSlot != null) footerSlot,
-      ],
+      children: [?headerSlot, _buildForm(), ?footerSlot],
     );
   }
 

--- a/lib/src/ui/views/teams/magic_starter_team_invitation_accept_view.dart
+++ b/lib/src/ui/views/teams/magic_starter_team_invitation_accept_view.dart
@@ -67,7 +67,7 @@ class _MagicStarterTeamInvitationAcceptViewState
       child: WDiv(
         className: 'flex flex-col items-center gap-6',
         children: [
-          if (headerSlot != null) headerSlot,
+          ?headerSlot,
           WDiv(
             className:
                 'w-16 h-16 rounded-full bg-primary/10 dark:bg-primary/10 flex items-center justify-center',
@@ -85,7 +85,7 @@ class _MagicStarterTeamInvitationAcceptViewState
               className: 'text-center',
             ),
           ),
-          if (footerSlot != null) footerSlot,
+          ?footerSlot,
         ],
       ),
     );
@@ -98,7 +98,7 @@ class _MagicStarterTeamInvitationAcceptViewState
       child: WDiv(
         className: 'flex flex-col items-center gap-4',
         children: [
-          if (headerSlot != null) headerSlot,
+          ?headerSlot,
           WDiv(
             className:
                 'w-16 h-16 rounded-full bg-green-50 dark:bg-green-900/20 flex items-center justify-center',
@@ -119,7 +119,7 @@ class _MagicStarterTeamInvitationAcceptViewState
               className: 'text-sm font-semibold text-primary',
             ),
           ),
-          if (footerSlot != null) footerSlot,
+          ?footerSlot,
         ],
       ),
     );
@@ -133,7 +133,7 @@ class _MagicStarterTeamInvitationAcceptViewState
       child: WDiv(
         className: 'flex flex-col items-center gap-4',
         children: [
-          if (headerSlot != null) headerSlot,
+          ?headerSlot,
           WDiv(
             className:
                 'w-16 h-16 rounded-full bg-red-50 dark:bg-red-900/20 flex items-center justify-center',
@@ -150,7 +150,7 @@ class _MagicStarterTeamInvitationAcceptViewState
               className: 'text-sm font-semibold text-primary',
             ),
           ),
-          if (footerSlot != null) footerSlot,
+          ?footerSlot,
         ],
       ),
     );

--- a/lib/src/ui/views/teams/magic_starter_team_settings_view.dart
+++ b/lib/src/ui/views/teams/magic_starter_team_settings_view.dart
@@ -99,11 +99,11 @@ class _MagicStarterTeamSettingsViewState
       title: trans('teams.settings'),
       subtitle: trans('teams.settings_subtitle'),
       children: [
-        if (headerSlot != null) headerSlot,
+        ?headerSlot,
         _buildGeneralSection(),
         _buildMembersSection(),
-        if (afterMembersSlot != null) afterMembersSlot,
-        if (footerSlot != null) footerSlot,
+        ?afterMembersSlot,
+        ?footerSlot,
       ],
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,15 +27,19 @@ dependencies:
   magic: ^0.0.6
   fluttersdk_artisan: ^0.0.9
   magic_notifications: ^0.0.2
-  # Unpublished, so this constraint cannot be bumped to name what the billing
-  # screen needs: `BillingCycle` and `PlanStatus.isDunning` both arrived after
-  # the pubspec said `^0.0.1`, and there is no released version between them to
-  # point at. `^0.0.1` is `>=0.0.1 <0.0.2`, and the 0.0.1 that eventually
-  # publishes carries both, because it publishes from a default branch that has
-  # them. What that leaves is a RELEASE ORDER rather than a constraint:
-  # magic_payments 0.0.1 must be on pub.dev, carrying both, before this package
-  # can publish at all. CI says so out loud in the `Published graph` job instead
-  # of resolving green against a graph no adopter can install.
+  # Unpublished: magic_payments has no release on pub.dev at all, so a
+  # resolution with no local overrides fails outright. `BillingCycle` and
+  # `PlanStatus.isDunning`, which the billing screen needs, sit on its default
+  # branch and have never shipped in a version anybody can install.
+  #
+  # The constraint is not what holds this back. `^0.0.1` is `>=0.0.1 <0.1.0`:
+  # pub_semver raises the first NON-ZERO component for the upper bound
+  # (`Version.nextBreaking`), so a caret on a `0.0.x` tracks the whole `0.0.x`
+  # line rather than pinning one patch, and this already admits whichever
+  # release eventually carries both. What is left is a RELEASE ORDER:
+  # magic_payments must be on pub.dev, carrying both, before this package can
+  # publish at all. CI says so out loud in the `Published graph` job instead of
+  # resolving green against a graph no adopter can install.
   magic_payments: ^0.0.1
   args: ^2.7.0
   path: ^1.9.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,10 +33,13 @@ dependencies:
   # branch and have never shipped in a version anybody can install.
   #
   # The constraint is not what holds this back. `^0.0.1` is `>=0.0.1 <0.1.0`:
-  # pub_semver raises the first NON-ZERO component for the upper bound
-  # (`Version.nextBreaking`), so a caret on a `0.0.x` tracks the whole `0.0.x`
-  # line rather than pinning one patch, and this already admits whichever
-  # release eventually carries both. What is left is a RELEASE ORDER:
+  # pub_semver's `Version.nextBreaking` raises the MINOR whenever the major is
+  # zero, whatever the minor itself is (`version.dart:243`), so a caret on any
+  # `0.0.x` tracks the whole `0.0.x` line rather than pinning one patch, and
+  # this already admits whichever release eventually carries both. Do not
+  # restate this as "the first non-zero component": for `0.0.1` that is the
+  # patch, which yields `<0.0.2` and is the wrong bound this comment exists to
+  # correct. What is left is a RELEASE ORDER:
   # magic_payments must be on pub.dev, carrying both, before this package can
   # publish at all. CI says so out loud in the `Published graph` job instead of
   # resolving green against a graph no adopter can install.

--- a/test/cli/commands/magic_starter_install_command_test.dart
+++ b/test/cli/commands/magic_starter_install_command_test.dart
@@ -53,7 +53,7 @@ Future<int> runInstall(
     'dry-run': false,
     'non-interactive': nonInteractive,
     'no-bootstrap': false,
-    if (features != null) 'features': features,
+    'features': ?features,
   };
   final ctx = ArtisanContext.bare(MapInput(options), BufferedOutput());
   return command.handle(ctx);

--- a/test/facades/magic_starter_facade_test.dart
+++ b/test/facades/magic_starter_facade_test.dart
@@ -31,7 +31,7 @@ void main() {
       });
 
       test('hasSocialLogin returns true after useSocialLogin()', () {
-        MagicStarter.useSocialLogin((_, __) => const SizedBox());
+        MagicStarter.useSocialLogin((_, _) => const SizedBox());
 
         expect(MagicStarter.hasSocialLogin, isTrue);
       });

--- a/test/magic_starter_manager_test.dart
+++ b/test/magic_starter_manager_test.dart
@@ -30,7 +30,7 @@ void main() {
       });
 
       test('reset() clears socialLoginBuilder', () {
-        manager.socialLoginBuilder = (_, __) => const SizedBox();
+        manager.socialLoginBuilder = (_, _) => const SizedBox();
 
         manager.reset();
 


### PR DESCRIPTION
## What

Three commits, in order.

**1. `docs`: correct the caret claim and five stale numbers.**

The comment beside `magic_payments: ^0.0.1` asserted that `^0.0.1` is `>=0.0.1 <0.0.2` and built a release argument on top of it. It is `>=0.0.1 <0.1.0`: pub_semver raises the first NON-ZERO component for the upper bound (`Version.nextBreaking`, `version.dart:243`). Verified rather than recalled, with `VersionConstraint.compatibleWith(Version.parse('0.0.6')).allows(Version.parse('0.0.7')) == true`.

The conclusion is unchanged, because it never rested on the constraint: `magic_payments` has no release on pub.dev at all, so this is a release ORDER. The reasoning under it is now the real one. As written, it would send the next reader looking for a version bump that is neither needed nor possible.

`CLAUDE.md` had drifted on five facts a contributor would act on, each recounted from the source: version `0.0.1-alpha.14` against a pubspec at `alpha.20`, Dart `>=3.6.0` / Flutter `>=3.27.0` against `>=3.11.0` / `>=3.41.0`, 47 barrel exports against 91, and "~62 files, ~996 cases" against 107 files and roughly 1394.

**2. `style`: apply the two `dart fix` codes the analyzer had been reporting.**

44 infos across 20 files, all applied by the SDK's own fixes rather than by hand:

- `use_null_aware_elements` (38): `if (x != null) x!` inside a collection literal becomes `?x`.
- `unnecessary_underscores` (6): `(_, __, ___)` becomes `(_, _, _)`.

Both features sit well inside this package's floor (`sdk: >=3.11.0`). `magic_starter` carried all of these on its own; `magic`, `magic_notifications` and `wind` report zero, because the pattern the first rule targets is a UI-collection idiom and this is the UI-heavy package.

**3. `ci`: make analyzer infos fatal.**

`--no-fatal-infos` is why 44 infos could sit in the tree without anything going red. With the tree clean the flag has nothing left to tolerate, and dropping it is what stops the next 44 accumulating the same way. All three call sites, so a contributor cannot pass one gate and fail another: both jobs in `ci.yml` and the one in `publish.yml`. The published-graph job keeps its `continue-on-error: true`, so this does not change whether it blocks.

## Why

Nothing in the first commit is cosmetic: a pubspec comment that misstates caret semantics is the kind of wrong that gets believed, and it is a belief that has cost this ecosystem a wrong re-pin before.

The lint debt and the CI flag are one decision, not two. Clearing the debt without closing the gate means doing it again next quarter.

## Testing

- `dart analyze`: 44 issues before, **0 after**
- `dart format --output=none --set-exit-if-changed lib test`: clean
- `flutter test`: **1394 passing**, identical before and after the fixes

The `dart fix` transforms are behaviour-preserving by construction, and the suite agreeing at the same count on both sides is the check that they were.

## Cost worth stating

A Dart SDK upgrade that ships a new lint now turns CI red with no code change. That is the intended trade: the alternative is what commit 2 is cleaning up.