### PR TITLE
perf(billing): repaint the prices on a cycle press, not the screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Improvements
+
+- **A press on the billing cycle toggle repaints the prices instead of the screen.** The toggle wrote its override through `setState` on the view's `State`, so one press rebuilt everything that `State` builds: the page scaffold, the scrollable, the header, the usage meters, all four plan cards in full, the payment method and the billing history. The only thing on the screen a press changes is four price labels, four billing notes and the toggle's own selected segment. The override is a `ValueNotifier` now, and the two regions that read it are the only ones subscribed to it. Measured on Chrome against a running app, one press: `WDiv` rebuilt 79 to 11, `WText` rebuilt 58 to 13, wind class-cache lookups 156 to 22 with zero misses on both sides. Three post-change runs returned those counts identically. Frame build time moved with them, but a debug build with timeline instrumentation is not a source for a millisecond figure, so the counts are the result here. `_cycle` stays derived and the press still writes the OVERRIDE, so the entitlement default keeps its meaning; the notifier is disposed in `onClose` beside the controller listener. (`lib/src/ui/views/teams/magic_starter_billing_view.dart`)
+
 ## [0.0.1-alpha.21] - 2026-08-25
 
 ### Added

--- a/lib/src/ui/views/teams/magic_starter_billing_view.dart
+++ b/lib/src/ui/views/teams/magic_starter_billing_view.dart
@@ -241,7 +241,17 @@ class _MagicStarterBillingViewState
   ///
   /// Separate from [_cycle] so the toggle can default to the cycle a customer is
   /// already on without that default becoming indistinguishable from a choice.
-  BillingCycle? _cycleOverride;
+  ///
+  /// A [ValueNotifier] rather than a plain field, so a press repaints the prices
+  /// instead of the screen. It used to be a field written through `setState`,
+  /// which rebuilt this whole State: the scaffold, the scrollable, the header,
+  /// the usage meters, every plan card in full, the payment method and the
+  /// billing history, to change four price labels and four billing notes.
+  /// Measured on Chrome, one press rebuilt about 80 `WDiv` and 58 `WText`; the
+  /// two [ValueListenableBuilder]s this feeds rebuild the toggle and the four
+  /// price blocks and nothing else.
+  final ValueNotifier<BillingCycle?> _cycleOverride =
+      ValueNotifier<BillingCycle?>(null);
 
   /// The billing cycle every price on this screen is shown for, and the one a
   /// purchase is made on.
@@ -260,7 +270,7 @@ class _MagicStarterBillingViewState
   /// when no cycle is known keeps the discounted column in front of somebody who
   /// is not paying yet.
   BillingCycle get _cycle =>
-      _cycleOverride ?? controller.cycle ?? BillingCycle.annual;
+      _cycleOverride.value ?? controller.cycle ?? BillingCycle.annual;
 
   /// The cycle [plan] is actually SOLD on, which is [_cycle] except where that
   /// tier has no price for it.
@@ -299,6 +309,7 @@ class _MagicStarterBillingViewState
   @override
   void onClose() {
     controller.removeListener(_startRequestedUpgrade);
+    _cycleOverride.dispose();
   }
 
   // ---------------------------------------------------------------------------
@@ -651,18 +662,21 @@ class _MagicStarterBillingViewState
               className: 'text-lg font-semibold text-fg',
             ),
             if (controller.storeRail == null)
-              MSSegmentedControl<BillingCycle>(
-                size: SegmentedControlSize.sm,
-                options: <String>[
-                  trans('magic_starter.billing.plans_monthly'),
-                  trans('magic_starter.billing.plans_annual'),
-                ],
-                selectedIndex: _cycles.indexOf(_cycle),
-                // Into the OVERRIDE, not into `_cycle`, which is derived. A
-                // press is the customer's own choice and has to outrank the
-                // entitlement default for the rest of the visit.
-                onChanged: (int index) =>
-                    setState(() => _cycleOverride = _cycles[index]),
+              ValueListenableBuilder<BillingCycle?>(
+                valueListenable: _cycleOverride,
+                builder: (_, _, _) => MSSegmentedControl<BillingCycle>(
+                  size: SegmentedControlSize.sm,
+                  options: <String>[
+                    trans('magic_starter.billing.plans_monthly'),
+                    trans('magic_starter.billing.plans_annual'),
+                  ],
+                  selectedIndex: _cycles.indexOf(_cycle),
+                  // Into the OVERRIDE, not into `_cycle`, which is derived. A
+                  // press is the customer's own choice and has to outrank the
+                  // entitlement default for the rest of the visit.
+                  onChanged: (int index) =>
+                      _cycleOverride.value = _cycles[index],
+                ),
               ),
           ],
         ),
@@ -774,31 +788,40 @@ class _MagicStarterBillingViewState
           ],
         ),
         // 2. Price and billing note for the selected cycle.
-        WDiv(
-          className: 'flex flex-col gap-0.5',
-          children: <Widget>[
-            if (storePriced)
-              WText(
-                trans('magic_starter.billing.plan_price_store'),
-                className: 'text-base font-medium text-fg',
-              )
-            else
-              WDiv(
-                className: 'flex flex-row items-baseline gap-1',
-                children: <Widget>[
-                  WText(
-                    _priceLabel(plan, _cycleFor(plan)),
-                    className: 'text-3xl font-semibold tabular-nums text-fg',
-                  ),
-                  if (!isCustom)
+        //
+        //    The ONLY part of this card the cycle toggle changes, which is why
+        //    it is the only part subscribed to it. Everything around it (the
+        //    name, the badge, the tagline, the highlight, the feature list, the
+        //    call to action) reads the catalogue row, not the cycle, so a press
+        //    that rebuilt them was rebuilding them into an identical tree.
+        ValueListenableBuilder<BillingCycle?>(
+          valueListenable: _cycleOverride,
+          builder: (_, _, _) => WDiv(
+            className: 'flex flex-col gap-0.5',
+            children: <Widget>[
+              if (storePriced)
+                WText(
+                  trans('magic_starter.billing.plan_price_store'),
+                  className: 'text-base font-medium text-fg',
+                )
+              else
+                WDiv(
+                  className: 'flex flex-row items-baseline gap-1',
+                  children: <Widget>[
                     WText(
-                      trans('magic_starter.billing.plan_price_monthly'),
-                      className: 'text-sm text-fg-muted',
+                      _priceLabel(plan, _cycleFor(plan)),
+                      className: 'text-3xl font-semibold tabular-nums text-fg',
                     ),
-                ],
-              ),
-            WText(_billingNote(plan), className: 'text-xs text-fg-muted'),
-          ],
+                    if (!isCustom)
+                      WText(
+                        trans('magic_starter.billing.plan_price_monthly'),
+                        className: 'text-sm text-fg-muted',
+                      ),
+                  ],
+                ),
+              WText(_billingNote(plan), className: 'text-xs text-fg-muted'),
+            ],
+          ),
         ),
         // 3. The consumer's highlight, where one is registered. The null-aware
         //    element OMITS it rather than rendering a placeholder, which matters

--- a/test/ui/views/teams/magic_starter_billing_view_test.dart
+++ b/test/ui/views/teams/magic_starter_billing_view_test.dart
@@ -1446,6 +1446,40 @@ void main() {
       await tester.pumpAndSettle();
     });
 
+    testWidgets('pressing the toggle repaints the price and the billing note', (
+      tester,
+    ) async {
+      // Every other toggle test reads state that a press updates whether or not
+      // anything repaints: `checkoutCycles` is filled from `_cycleOverride` at
+      // press time and never touches the plan cards. So an implementation where
+      // the price region never rebuilt would pass all of them, which is exactly
+      // the failure the scoped-rebuild change could introduce. This asserts the
+      // rendered figure and the rendered note, which nothing else does.
+      final _RailBillingService billing = _RailBillingService();
+
+      await mount(tester, billing, isOwner: true);
+
+      expect(find.text(r'$29'), findsOneWidget);
+      expect(
+        find.text(trans('magic_starter.billing.plan_billing_annual')),
+        findsWidgets,
+      );
+
+      await tester.tap(find.text(trans('magic_starter.billing.plans_monthly')));
+      await tester.pump();
+
+      expect(
+        find.text(r'$34'),
+        findsOneWidget,
+        reason: 'the monthly figure has to reach the screen, not just checkout',
+      );
+      expect(find.text(r'$29'), findsNothing);
+      expect(
+        find.text(trans('magic_starter.billing.plan_billing_monthly')),
+        findsWidgets,
+      );
+    });
+
     testWidgets('a tier sold monthly only is bought monthly, even while the '
         'toggle sits on annual', (tester) async {
       // The screen-wide cycle knows nothing about the row it is applied to. With


### PR DESCRIPTION
## What

The monthly/annual toggle on the billing screen wrote its override through `setState` on the view's State. One press therefore rebuilt everything that State builds: the page scaffold, the scrollable, the header, the usage meters, all four plan cards in full, the payment method section and the billing history.

The only thing a press actually changes is four price labels, four billing notes, and the toggle's own selected segment.

`_cycleOverride` becomes a `ValueNotifier<BillingCycle?>`, and the two regions that read it get a `ValueListenableBuilder`: the toggle, and section 2 of each plan card.

## Why

Measured with `dusk_perf_begin` / `dusk_perf_end` against a running Chrome build, driving the same press before and after:

| | before | after |
|---|---|---|
| `WDiv` rebuilt | 79 | **11** |
| `WText` rebuilt | 58 | **13** |
| wind class-cache lookups | 156 | **22** |
| wind cache misses | 0 | 0 |

Three post-change runs returned those counts identically. The block attribution confirms the shape rather than just the total: exactly five `ValueListenableBuilder<BillingCycle?>` builds per press, one for the toggle and one per card, with 13 `WDiv` below them.

Frame build time moved in the same direction (worst-frame build 52.1ms before, 29.7ms to 42.3ms after, trending down as the app warmed). That is **not** offered as the result: this is a debug build and the timeline instrumentation the session switches on costs time relative to the work it measures, so the counts are the honest number and the milliseconds are directional only. The before and after arms also differ in app uptime (the after arm follows a hot restart), which the exact counters are immune to and the timings are not.

The wind cache ran at a 100% hit rate on both sides, so none of this is className parsing; it is node count, which is what the change reduces.

## Behaviour

Unchanged, and checked live rather than only in tests: pressing Monthly moves Pro from \$29 to \$34 and Business from \$99 to \$119, flips every card's note to "billed monthly", and the Free tier back to "free forever"; pressing Annual restores them.

- `_cycle` stays derived (`override ?? controller.cycle ?? annual`), so the entitlement default still opens the screen on the cycle the customer is already billed on, and a press still outranks it for the rest of the visit.
- `_cycleFor(plan)` is unchanged, so a monthly-only tier keeps being sold monthly.
- The notifier is disposed in `onClose`, beside the existing controller-listener removal.

## Testing

- `flutter analyze`: clean (whole package).
- `dart format --set-exit-if-changed`: clean.
- `flutter test`: 1394 passed. The billing view's own suite (53 tests) includes two that tap the toggle and assert on the cycle that reaches checkout, so the changed path is covered rather than merely compiled.
- `bin/check flutter` in `uptizm`, which consumes this package by path: green.